### PR TITLE
fix example command to include standard library path

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Note that you have to clone this project with `--recursive` option, as the core 
   
   Then compile it with `ocamlscript`
   ```sh
-  OCAML_RAW_JS=1 ocamlscript -I . -I ../ -c hello.ml
+  OCAML_RAW_JS=1 ocamlscript -I . -I ../ -I ../stdlib -c hello.ml
   ```
   
   It should generate a file called `hello.js`, which can be executed with any JavaScript engine. In this example, we use Node.js


### PR DESCRIPTION
This is a quick fix. 

Maybe we should consider: 
* add help doc to `-I` option
* add documentation on how to use the generated js to interoperate with other js code. 