### PR TITLE
Exit code simplify

### DIFF
--- a/jscomp/lam_compile.ml
+++ b/jscomp/lam_compile.ml
@@ -729,9 +729,6 @@ and
 
       let exit_id =   Ext_ident.gen_js ~name:"exit" () in
       let exit_expr = E.var exit_id in
-      (* let code_jmps =  *)
-      (*   List.map (fun (i,_,bindings) ->  *)
-      (*     (i, exit_id,  bindings ) ) code_table in *)
       let bindings = Ext_list.flat_map (fun (_,_,bindings) -> bindings) code_table in
 
       (* compile_list name l false (\*\) *)
@@ -747,8 +744,8 @@ and
            (catch (catch (catch ..))
       *)
       (* TODO: handle NeedValue *)
-      let jmp_table =  Lam_compile_defs.add_jmps (exit_id, code_table) jmp_table in
-      let handlers = List.map (fun (i,lam,_) -> (i,lam) ) code_table in
+      let jmp_table, handlers =  Lam_compile_defs.add_jmps (exit_id, code_table) jmp_table in
+
       (* Declaration First, body and handler have the same value *)
       (* There is a bug in google closure compiler:
             https://github.com/google/closure-compiler/issues/1234#issuecomment-151976340 

--- a/jscomp/lam_compile.ml
+++ b/jscomp/lam_compile.ml
@@ -709,7 +709,7 @@ and
               ) largs (args : Ident.t list)) 
           in
           args_code ++ (* Declared in [Lstaticraise ]*)
-          Js_output.make [S.assign exit_id (E.int i)]
+          Js_output.make [S.assign exit_id (E.int order_id)]
             ~value:(E.undefined ())
         | exception Not_found ->
           Js_output.make [S.unknown_lambda ~comment:"error" lam]
@@ -743,6 +743,18 @@ and
          - another common scenario is that we have nested catch
            (catch (catch (catch ..))
       *)
+      (*
+        checkout example {!Digest.file}, you can not inline handler there, 
+        we can spot such patten and use finally there?
+        {[
+        let file filename =
+           let ic = open_in_bin filename in
+           match channel ic (-1) with
+           | d -> close_in ic; d
+           | exception e -> close_in ic; raise e
+
+        ]}
+       *)
       (* TODO: handle NeedValue *)
       let jmp_table, handlers =  Lam_compile_defs.add_jmps (exit_id, code_table) jmp_table in
 
@@ -752,8 +764,9 @@ and
             TODO: wait for a bug fix
         *)
       let declares = 
-        S.define ~kind:Variable exit_id ~comment:"initialize"
-          (E.int (cxt.meta.unused_exit_code)) :: 
+        S.define ~kind:Variable exit_id
+          (E.int 0) :: 
+        (* we should always make it zero here, since [zero] is reserved in our mapping*)
         List.map (fun x -> S.declare_variable ~kind:Variable x ) bindings in
 
       begin match  st with 

--- a/jscomp/lam_compile.ml
+++ b/jscomp/lam_compile.ml
@@ -696,7 +696,7 @@ and
       (* [i] is the jump table, [largs] is the arguments passed to [Lstaticcatch]*)
       begin
         match Lam_compile_defs.HandlerMap.find i cxt.jmp_table  with 
-        | {exit_id; args } -> 
+        | {exit_id; args ; order_id} -> 
           let args_code  =
             (Js_output.concat @@ List.map2 (
                 fun (x : Lambda.lambda) (arg : Ident.t) ->
@@ -729,11 +729,11 @@ and
 
       let exit_id =   Ext_ident.gen_js ~name:"exit" () in
       let exit_expr = E.var exit_id in
-      let code_jmps = 
-        List.map (fun (i,_,bindings) -> 
-          (i, exit_id,  bindings ) ) code_table in
+      (* let code_jmps =  *)
+      (*   List.map (fun (i,_,bindings) ->  *)
+      (*     (i, exit_id,  bindings ) ) code_table in *)
       let bindings = Ext_list.flat_map (fun (_,_,bindings) -> bindings) code_table in
-      let handlers = List.map (fun (i,lam,_) -> (i,lam) ) code_table in
+
       (* compile_list name l false (\*\) *)
       (* if exit_code_id == code 
          handler -- ids are not useful, since 
@@ -747,7 +747,8 @@ and
            (catch (catch (catch ..))
       *)
       (* TODO: handle NeedValue *)
-      let jmp_table =  Lam_compile_defs.add_jmps code_jmps jmp_table in
+      let jmp_table =  Lam_compile_defs.add_jmps (exit_id, code_table) jmp_table in
+      let handlers = List.map (fun (i,lam,_) -> (i,lam) ) code_table in
       (* Declaration First, body and handler have the same value *)
       (* There is a bug in google closure compiler:
             https://github.com/google/closure-compiler/issues/1234#issuecomment-151976340 

--- a/jscomp/lam_compile.ml
+++ b/jscomp/lam_compile.ml
@@ -772,10 +772,7 @@ and
       begin match  st with 
          (* could be optimized when cases are less than 3 *)
          | NeedValue -> 
-           let v = Ext_ident.gen_js (* ~name:"exit_value" *) () in 
-
-           (* let _ret_value =  *)
-           (*   match lbody with {value= Some v; _ } -> v  | _ -> assert false in *)
+           let v = Ext_ident.gen_js  () in 
            let lbody = compile_lambda {cxt with 
                                        jmp_table = jmp_table;
                                        st = Assign v

--- a/jscomp/lam_compile.ml
+++ b/jscomp/lam_compile.ml
@@ -731,7 +731,7 @@ and
       let exit_expr = E.var exit_id in
       let code_jmps = 
         List.map (fun (i,_,bindings) -> 
-            (i, ({exit_id; args = bindings} : Lam_compile_defs.value) )) code_table in
+          (i, exit_id,  bindings ) ) code_table in
       let bindings = Ext_list.flat_map (fun (_,_,bindings) -> bindings) code_table in
       let handlers = List.map (fun (i,lam,_) -> (i,lam) ) code_table in
       (* compile_list name l false (\*\) *)

--- a/jscomp/lam_compile_defs.ml
+++ b/jscomp/lam_compile_defs.ml
@@ -74,10 +74,10 @@ type cxt = {
 let empty_handler_map = HandlerMap.empty
 
 
-let add_jmps (ls : (jbl_label * Ident.t * Ident.t list) list)   
+let add_jmps (exit_id, code_table)   
     (m : value HandlerMap.t) : value HandlerMap.t = 
   let i = HandlerMap.cardinal m in
   fst @@ List.fold_left 
-           (fun (acc,order_id) (l,exit_id, args)   -> 
+           (fun (acc,order_id) (l,_, args)   -> 
              (HandlerMap.add l {exit_id ; args; order_id} acc, order_id + 1))
-           (m,i) ls
+           (m,i) code_table

--- a/jscomp/lam_compile_defs.ml
+++ b/jscomp/lam_compile_defs.ml
@@ -76,17 +76,19 @@ let empty_handler_map = HandlerMap.empty
 
 let add_jmps (exit_id, code_table)   
     (m : value HandlerMap.t) = 
-  let i = HandlerMap.cardinal m in
-
   (* always keep key id positive, specifically no [0] generated
    *)
   let map, _, handlers = 
     List.fold_left 
-           (fun (acc,order_id, handlers)
+           (fun (acc,prev_order_id, handlers) 
                (l,lam, args)   -> 
-                 (HandlerMap.add l {exit_id ; args; order_id = order_id + 1} acc, 
-                  order_id + 1,
-                  (order_id + 1,lam) :: handlers
-                 ))
-      (m,i, []) code_table in
+                 let order_id = prev_order_id + 1 in
+                 (HandlerMap.add l {exit_id ; args; order_id } acc, 
+                  order_id ,
+                  (order_id, lam) :: handlers))
+      (m,
+       HandlerMap.cardinal m,
+       []
+      )
+      code_table in
   map, List.rev handlers

--- a/jscomp/lam_compile_defs.ml
+++ b/jscomp/lam_compile_defs.ml
@@ -27,7 +27,11 @@ module HandlerMap = Map.Make(struct
   let compare x y= compare (x:t) y 
 end )
 
-type value = { exit_id : Ident.t ; args : Ident.t list }
+type value = {
+    exit_id : Ident.t ;
+    args : Ident.t list ;
+    order_id : int
+  }
 
 (* delegate to the callee to generate expression 
       Invariant: [output] should return a trailing expression
@@ -70,6 +74,10 @@ type cxt = {
 let empty_handler_map = HandlerMap.empty
 
 
-let add_jmps (ls : (jbl_label * value) list)   
+let add_jmps (ls : (jbl_label * Ident.t * Ident.t list) list)   
     (m : value HandlerMap.t) : value HandlerMap.t = 
-  List.fold_left (fun acc (l,s)   -> HandlerMap.add l s acc) m ls
+  let i = HandlerMap.cardinal m in
+  fst @@ List.fold_left 
+           (fun (acc,order_id) (l,exit_id, args)   -> 
+             (HandlerMap.add l {exit_id ; args; order_id} acc, order_id + 1))
+           (m,i) ls

--- a/jscomp/lam_compile_defs.ml
+++ b/jscomp/lam_compile_defs.ml
@@ -68,3 +68,8 @@ type cxt = {
 }
 
 let empty_handler_map = HandlerMap.empty
+
+
+let add_jmps (ls : (jbl_label * value) list)   
+    (m : value HandlerMap.t) : value HandlerMap.t = 
+  List.fold_left (fun acc (l,s)   -> HandlerMap.add l s acc) m ls

--- a/jscomp/lam_compile_defs.ml
+++ b/jscomp/lam_compile_defs.ml
@@ -75,9 +75,15 @@ let empty_handler_map = HandlerMap.empty
 
 
 let add_jmps (exit_id, code_table)   
-    (m : value HandlerMap.t) : value HandlerMap.t = 
+    (m : value HandlerMap.t) = 
   let i = HandlerMap.cardinal m in
-  fst @@ List.fold_left 
-           (fun (acc,order_id) (l,_, args)   -> 
-             (HandlerMap.add l {exit_id ; args; order_id} acc, order_id + 1))
-           (m,i) code_table
+  let map, _, handlers = 
+    List.fold_left 
+           (fun (acc,order_id, handlers)
+               (l,lam, args)   -> 
+                 (HandlerMap.add l {exit_id ; args; order_id} acc, 
+                  order_id + 1,
+                  (l,lam) :: handlers
+                 ))
+      (m,i, []) code_table in
+  map, List.rev handlers

--- a/jscomp/lam_compile_defs.ml
+++ b/jscomp/lam_compile_defs.ml
@@ -77,13 +77,16 @@ let empty_handler_map = HandlerMap.empty
 let add_jmps (exit_id, code_table)   
     (m : value HandlerMap.t) = 
   let i = HandlerMap.cardinal m in
+
+  (* always keep key id positive, specifically no [0] generated
+   *)
   let map, _, handlers = 
     List.fold_left 
            (fun (acc,order_id, handlers)
                (l,lam, args)   -> 
-                 (HandlerMap.add l {exit_id ; args; order_id} acc, 
+                 (HandlerMap.add l {exit_id ; args; order_id = order_id + 1} acc, 
                   order_id + 1,
-                  (l,lam) :: handlers
+                  (order_id + 1,lam) :: handlers
                  ))
       (m,i, []) code_table in
   map, List.rev handlers

--- a/jscomp/lam_compile_defs.mli
+++ b/jscomp/lam_compile_defs.mli
@@ -29,9 +29,13 @@
 
 type jbl_label = int 
 
-module HandlerMap : Map.S with type key = jbl_label
 
-type value = { exit_id : Ident.t ; args : Ident.t list }
+
+type value = {
+    exit_id : Ident.t ; 
+    args : Ident.t list ;
+    order_id : int
+  }
 
 type let_kind = Lambda.let_kind
 
@@ -61,6 +65,8 @@ type return_type =
       Invariant: [output] should return a trailing expression
   *)
 
+module HandlerMap : Map.S with type key = jbl_label
+
 type cxt = {
   st : st ;
   should_return : return_type;
@@ -70,4 +76,4 @@ type cxt = {
 
 val empty_handler_map : value HandlerMap.t 
 
-val add_jmps : (jbl_label * value) list -> value HandlerMap.t -> value HandlerMap.t
+val add_jmps : (jbl_label * Ident.t * Ident.t list) list -> value HandlerMap.t -> value HandlerMap.t

--- a/jscomp/lam_compile_defs.mli
+++ b/jscomp/lam_compile_defs.mli
@@ -76,4 +76,7 @@ type cxt = {
 
 val empty_handler_map : value HandlerMap.t 
 
-val add_jmps : (jbl_label * Ident.t * Ident.t list) list -> value HandlerMap.t -> value HandlerMap.t
+val add_jmps :
+    Ident.t * (HandlerMap.key * 'a * Ident.t list) list ->
+    value HandlerMap.t -> value HandlerMap.t
+

--- a/jscomp/lam_compile_defs.mli
+++ b/jscomp/lam_compile_defs.mli
@@ -69,3 +69,5 @@ type cxt = {
 }
 
 val empty_handler_map : value HandlerMap.t 
+
+val add_jmps : (jbl_label * value) list -> value HandlerMap.t -> value HandlerMap.t

--- a/jscomp/lam_compile_defs.mli
+++ b/jscomp/lam_compile_defs.mli
@@ -78,5 +78,5 @@ val empty_handler_map : value HandlerMap.t
 
 val add_jmps :
     Ident.t * (HandlerMap.key * 'a * Ident.t list) list ->
-    value HandlerMap.t -> value HandlerMap.t
+    value HandlerMap.t -> value HandlerMap.t * (int * 'a) list
 

--- a/jscomp/lam_pass_collect.ml
+++ b/jscomp/lam_pass_collect.ml
@@ -161,7 +161,6 @@ let count_alias_globals
     {alias_tbl = Hashtbl.create 31 ; 
      ident_tbl = Hashtbl.create 31;
      exit_codes = Hash_set.create 31 ;
-     unused_exit_code = 0; 
      exports = export_idents;
      required_modules = [] ;
      filename;
@@ -169,5 +168,4 @@ let count_alias_globals
      export_idents
    } in 
   collect_helper  meta lam ; 
-  meta.unused_exit_code <- Lam_stats_util.find_unused_exit_code meta.exit_codes; 
   meta

--- a/jscomp/lam_stats.ml
+++ b/jscomp/lam_stats.ml
@@ -86,7 +86,7 @@ type meta = {
   mutable export_idents : Ident.t list;
   alias_tbl : alias_tbl; 
   exit_codes : int Hash_set.hashset;
-  mutable unused_exit_code : int ; (* clean up later*)
+
   ident_tbl : ident_tbl;
   (** we don't need count arities for all identifiers, for identifiers
       for sure it's not a function, there is no need to count them

--- a/jscomp/lam_stats.mli
+++ b/jscomp/lam_stats.mli
@@ -88,7 +88,7 @@ type meta = {
   mutable export_idents : Ident.t list;
   alias_tbl : alias_tbl; 
   exit_codes : int Hash_set.hashset;
-  mutable unused_exit_code : int ; (* clean up later, not used any more*)
+
   ident_tbl : ident_tbl;
   (** we don't need count arities for all identifiers, for identifiers
       for sure it's not a function, there is no need to count them

--- a/jscomp/lam_stats.mli
+++ b/jscomp/lam_stats.mli
@@ -88,7 +88,7 @@ type meta = {
   mutable export_idents : Ident.t list;
   alias_tbl : alias_tbl; 
   exit_codes : int Hash_set.hashset;
-  mutable unused_exit_code : int ; (* clean up later*)
+  mutable unused_exit_code : int ; (* clean up later, not used any more*)
   ident_tbl : ident_tbl;
   (** we don't need count arities for all identifiers, for identifiers
       for sure it's not a function, there is no need to count them

--- a/jscomp/stdlib/arg.js
+++ b/jscomp/stdlib/arg.js
@@ -389,7 +389,7 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
       try {
         var treat_action = (function(s){
         return function (param) {
-          /* initialize */var exit = 0;
+          var exit = 0;
           switch (param[0]) {
             case 0 : 
                 return param[1](/* () */0);
@@ -424,7 +424,7 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
                   return ++ current$1[1];
                 }
                 else {
-                  exit = 44;
+                  exit = 1;
                 }
                 break;
             case 2 : 
@@ -439,7 +439,7 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
                   return ++ current$1[1];
                 }
                 else {
-                  exit = 44;
+                  exit = 1;
                 }
                 break;
             case 5 : 
@@ -448,7 +448,7 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
                   return ++ current$1[1];
                 }
                 else {
-                  exit = 44;
+                  exit = 1;
                 }
                 break;
             case 6 : 
@@ -482,7 +482,7 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
                   return ++ current$1[1];
                 }
                 else {
-                  exit = 44;
+                  exit = 1;
                 }
                 break;
             case 7 : 
@@ -516,7 +516,7 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
                   return ++ current$1[1];
                 }
                 else {
-                  exit = 44;
+                  exit = 1;
                 }
                 break;
             case 8 : 
@@ -550,7 +550,7 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
                   return ++ current$1[1];
                 }
                 else {
-                  exit = 44;
+                  exit = 1;
                 }
                 break;
             case 9 : 
@@ -584,7 +584,7 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
                   return ++ current$1[1];
                 }
                 else {
-                  exit = 44;
+                  exit = 1;
                 }
                 break;
             case 10 : 
@@ -611,7 +611,7 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
                   }
                 }
                 else {
-                  exit = 44;
+                  exit = 1;
                 }
                 break;
             case 12 : 
@@ -623,7 +623,7 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
                 return /* () */0;
             
           }
-          if (exit === 44) {
+          if (exit === 1) {
             throw [
                   0,
                   Stop,

--- a/jscomp/stdlib/buffer.js
+++ b/jscomp/stdlib/buffer.js
@@ -199,14 +199,14 @@ function advance_to_non_alpha(s, start) {
       }
       else {
         var match = s.charCodeAt(i);
-        /* initialize */var exit = 0;
+        var exit = 0;
         if (match >= 91) {
           if (match >= 97) {
             if (match >= 123) {
               return i;
             }
             else {
-              exit = 14;
+              exit = 1;
             }
           }
           else {
@@ -214,14 +214,14 @@ function advance_to_non_alpha(s, start) {
               return i;
             }
             else {
-              exit = 14;
+              exit = 1;
             }
           }
         }
         else {
           if (match >= 58) {
             if (match >= 65) {
-              exit = 14;
+              exit = 1;
             }
             else {
               return i;
@@ -229,14 +229,14 @@ function advance_to_non_alpha(s, start) {
           }
           else {
             if (match >= 48) {
-              exit = 14;
+              exit = 1;
             }
             else {
               return i;
             }
           }
         }
-        if (exit === 14) {
+        if (exit === 1) {
           _i = i + 1;
         }
         
@@ -252,7 +252,7 @@ function find_ident(s, start, lim) {
   }
   else {
     var c = s.charCodeAt(start);
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (c !== 40) {
       if (c !== 123) {
         var stop = advance_to_non_alpha(s, start + 1);
@@ -263,13 +263,13 @@ function find_ident(s, start, lim) {
               ];
       }
       else {
-        exit = 11;
+        exit = 1;
       }
     }
     else {
-      exit = 11;
+      exit = 1;
     }
-    if (exit === 11) {
+    if (exit === 1) {
       var new_start = start + 1;
       var stop$1 = advance_to_closing(c, closing(c), 0, s, new_start);
       return [

--- a/jscomp/stdlib/bytes.js
+++ b/jscomp/stdlib/bytes.js
@@ -165,19 +165,19 @@ function escaped(s) {
   for(var i = 0 ,i_finish = s.length - 1; i<= i_finish; ++i){
     var c = s[i];
     var $js;
-    /* initialize */var exit = 0;
+    var exit = 0;
     c >= 14 ? (
         c !== 34 ? (
-            c !== 92 ? (exit = 30) : ($js = 2)
+            c !== 92 ? (exit = 1) : ($js = 2)
           ) : ($js = 2)
       ) : (
         c >= 11 ? (
-            c >= 13 ? ($js = 2) : (exit = 30)
+            c >= 13 ? ($js = 2) : (exit = 1)
           ) : (
-            c >= 8 ? ($js = 2) : (exit = 30)
+            c >= 8 ? ($js = 2) : (exit = 1)
           )
       );
-    if (exit === 30) {
+    if (exit === 1) {
       $js = Caml_string.caml_is_printable(c) ? 1 : 4;
     }
     n += $js;
@@ -190,7 +190,7 @@ function escaped(s) {
     n = 0;
     for(var i$1 = 0 ,i_finish$1 = s.length - 1; i$1<= i_finish$1; ++i$1){
       var c$1 = s[i$1];
-      /* initialize */var exit$1 = 0;
+      var exit$1 = 0;
       var switcher = -34 + c$1;
       if (!(58 < (switcher >>> 0))) {
         if (56 < (-1 + switcher >>> 0)) {
@@ -199,12 +199,12 @@ function escaped(s) {
           s$prime[n] = c$1;
         }
         else {
-          exit$1 = 27;
+          exit$1 = 1;
         }
       }
       else {
         if (switcher >= -20) {
-          exit$1 = 27;
+          exit$1 = 1;
         }
         else {
           switch (34 + switcher) {
@@ -233,7 +233,7 @@ function escaped(s) {
             case 7 : 
             case 11 : 
             case 12 : 
-                exit$1 = 27;
+                exit$1 = 1;
                 break;
             case 13 : 
                 s$prime[n] = /* "\\" */92;
@@ -244,7 +244,7 @@ function escaped(s) {
           }
         }
       }
-      if (exit$1 === 27) {
+      if (exit$1 === 1) {
         if (Caml_string.caml_is_printable(c$1)) {
           s$prime[n] = c$1;
         }

--- a/jscomp/stdlib/camlinternalFormat.js
+++ b/jscomp/stdlib/camlinternalFormat.js
@@ -362,14 +362,14 @@ function bprint_char_set(buf, char_set) {
   };
   var print_first = function (set, i) {
     var match = Pervasives.char_of_int(i);
-    /* initialize */var exit = 0;
+    var exit = 0;
     var switcher = -45 + match;
     if (!(48 < (switcher >>> 0))) {
       if (46 < (-1 + switcher >>> 0)) {
         return print_out(set, i + 1);
       }
       else {
-        exit = 375;
+        exit = 1;
       }
     }
     else {
@@ -377,10 +377,10 @@ function bprint_char_set(buf, char_set) {
         return print_char(buf, 255);
       }
       else {
-        exit = 375;
+        exit = 1;
       }
     }
-    if (exit === 375) {
+    if (exit === 1) {
       return print_second(set, i + 1);
     }
     
@@ -388,7 +388,7 @@ function bprint_char_set(buf, char_set) {
   var print_second = function (set, i) {
     if (is_in_char_set(set, Pervasives.char_of_int(i))) {
       var match = Pervasives.char_of_int(i);
-      /* initialize */var exit = 0;
+      var exit = 0;
       var switcher = -45 + match;
       if (!(48 < (switcher >>> 0))) {
         if (46 < (-1 + switcher >>> 0)) {
@@ -397,11 +397,11 @@ function bprint_char_set(buf, char_set) {
             return print_out(set, i + 1);
           }
           else {
-            exit = 376;
+            exit = 1;
           }
         }
         else {
-          exit = 376;
+          exit = 1;
         }
       }
       else {
@@ -410,10 +410,10 @@ function bprint_char_set(buf, char_set) {
           return print_char(buf, 255);
         }
         else {
-          exit = 376;
+          exit = 1;
         }
       }
-      if (exit === 376) {
+      if (exit === 1) {
         return !is_in_char_set(set, Pervasives.char_of_int(i + 1)) ? (print_char(buf, i - 1), print_char(buf, i), print_out(set, i + 2)) : print_in(set, i - 1, i + 2);
       }
       
@@ -485,7 +485,7 @@ function bprint_precision(buf, prec) {
 }
 
 function bprint_iconv_flag(buf, iconv) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   switch (iconv) {
     case 1 : 
     case 4 : 
@@ -496,7 +496,7 @@ function bprint_iconv_flag(buf, iconv) {
     case 7 : 
     case 9 : 
     case 11 : 
-        exit = 364;
+        exit = 1;
         break;
     case 0 : 
     case 3 : 
@@ -507,7 +507,7 @@ function bprint_iconv_flag(buf, iconv) {
         return /* () */0;
     
   }
-  if (exit === 364) {
+  if (exit === 1) {
     return buffer_add_char(buf, /* "#" */35);
   }
   
@@ -533,21 +533,21 @@ function bprint_altint_fmt(buf, ign_flag, iconv, pad, prec, c) {
 }
 
 function bprint_fconv_flag(buf, fconv) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   switch (fconv) {
     case 1 : 
     case 4 : 
     case 7 : 
     case 10 : 
     case 13 : 
-        exit = 356;
+        exit = 1;
         break;
     case 2 : 
     case 5 : 
     case 8 : 
     case 11 : 
     case 14 : 
-        exit = 357;
+        exit = 2;
         break;
     case 0 : 
     case 3 : 
@@ -559,9 +559,9 @@ function bprint_fconv_flag(buf, fconv) {
     
   }
   switch (exit) {
-    case 356 : 
+    case 1 : 
         return buffer_add_char(buf, /* "+" */43);
-    case 357 : 
+    case 2 : 
         return buffer_add_char(buf, /* " " */32);
     
   }
@@ -1295,7 +1295,7 @@ function fmtty_rel_det(param) {
 }
 
 function trans(ty1, ty2) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (typeof ty1 === "number") {
     if (typeof ty2 === "number") {
       if (ty2) {
@@ -1317,25 +1317,25 @@ function trans(ty1, ty2) {
     else {
       switch (ty2[0]) {
         case 8 : 
-            exit = 335;
+            exit = 6;
             break;
         case 9 : 
-            exit = 333;
+            exit = 7;
             break;
         case 10 : 
-            exit = 345;
+            exit = 1;
             break;
         case 11 : 
-            exit = 343;
+            exit = 2;
             break;
         case 12 : 
-            exit = 341;
+            exit = 3;
             break;
         case 13 : 
-            exit = 339;
+            exit = 4;
             break;
         case 14 : 
-            exit = 337;
+            exit = 5;
             break;
         default:
           throw [
@@ -1355,7 +1355,7 @@ function trans(ty1, ty2) {
     switch (ty1[0]) {
       case 0 : 
           if (typeof ty2 === "number") {
-            exit = 331;
+            exit = 8;
           }
           else {
             switch (ty2[0]) {
@@ -1365,25 +1365,25 @@ function trans(ty1, ty2) {
                           trans(ty1[1], ty2[1])
                         ];
               case 8 : 
-                  exit = 335;
+                  exit = 6;
                   break;
               case 9 : 
-                  exit = 333;
+                  exit = 7;
                   break;
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
-                  exit = 339;
+                  exit = 4;
                   break;
               case 14 : 
-                  exit = 337;
+                  exit = 5;
                   break;
               
             }
@@ -1391,7 +1391,7 @@ function trans(ty1, ty2) {
           break;
       case 1 : 
           if (typeof ty2 === "number") {
-            exit = 331;
+            exit = 8;
           }
           else {
             switch (ty2[0]) {
@@ -1401,25 +1401,25 @@ function trans(ty1, ty2) {
                           trans(ty1[1], ty2[1])
                         ];
               case 8 : 
-                  exit = 335;
+                  exit = 6;
                   break;
               case 9 : 
-                  exit = 333;
+                  exit = 7;
                   break;
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
-                  exit = 339;
+                  exit = 4;
                   break;
               case 14 : 
-                  exit = 337;
+                  exit = 5;
                   break;
               
             }
@@ -1427,7 +1427,7 @@ function trans(ty1, ty2) {
           break;
       case 2 : 
           if (typeof ty2 === "number") {
-            exit = 331;
+            exit = 8;
           }
           else {
             switch (ty2[0]) {
@@ -1437,25 +1437,25 @@ function trans(ty1, ty2) {
                           trans(ty1[1], ty2[1])
                         ];
               case 8 : 
-                  exit = 335;
+                  exit = 6;
                   break;
               case 9 : 
-                  exit = 333;
+                  exit = 7;
                   break;
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
-                  exit = 339;
+                  exit = 4;
                   break;
               case 14 : 
-                  exit = 337;
+                  exit = 5;
                   break;
               
             }
@@ -1463,7 +1463,7 @@ function trans(ty1, ty2) {
           break;
       case 3 : 
           if (typeof ty2 === "number") {
-            exit = 331;
+            exit = 8;
           }
           else {
             switch (ty2[0]) {
@@ -1473,25 +1473,25 @@ function trans(ty1, ty2) {
                           trans(ty1[1], ty2[1])
                         ];
               case 8 : 
-                  exit = 335;
+                  exit = 6;
                   break;
               case 9 : 
-                  exit = 333;
+                  exit = 7;
                   break;
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
-                  exit = 339;
+                  exit = 4;
                   break;
               case 14 : 
-                  exit = 337;
+                  exit = 5;
                   break;
               
             }
@@ -1499,7 +1499,7 @@ function trans(ty1, ty2) {
           break;
       case 4 : 
           if (typeof ty2 === "number") {
-            exit = 331;
+            exit = 8;
           }
           else {
             switch (ty2[0]) {
@@ -1509,25 +1509,25 @@ function trans(ty1, ty2) {
                           trans(ty1[1], ty2[1])
                         ];
               case 8 : 
-                  exit = 335;
+                  exit = 6;
                   break;
               case 9 : 
-                  exit = 333;
+                  exit = 7;
                   break;
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
-                  exit = 339;
+                  exit = 4;
                   break;
               case 14 : 
-                  exit = 337;
+                  exit = 5;
                   break;
               
             }
@@ -1535,7 +1535,7 @@ function trans(ty1, ty2) {
           break;
       case 5 : 
           if (typeof ty2 === "number") {
-            exit = 331;
+            exit = 8;
           }
           else {
             switch (ty2[0]) {
@@ -1545,25 +1545,25 @@ function trans(ty1, ty2) {
                           trans(ty1[1], ty2[1])
                         ];
               case 8 : 
-                  exit = 335;
+                  exit = 6;
                   break;
               case 9 : 
-                  exit = 333;
+                  exit = 7;
                   break;
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
-                  exit = 339;
+                  exit = 4;
                   break;
               case 14 : 
-                  exit = 337;
+                  exit = 5;
                   break;
               
             }
@@ -1571,7 +1571,7 @@ function trans(ty1, ty2) {
           break;
       case 6 : 
           if (typeof ty2 === "number") {
-            exit = 331;
+            exit = 8;
           }
           else {
             switch (ty2[0]) {
@@ -1581,25 +1581,25 @@ function trans(ty1, ty2) {
                           trans(ty1[1], ty2[1])
                         ];
               case 8 : 
-                  exit = 335;
+                  exit = 6;
                   break;
               case 9 : 
-                  exit = 333;
+                  exit = 7;
                   break;
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
-                  exit = 339;
+                  exit = 4;
                   break;
               case 14 : 
-                  exit = 337;
+                  exit = 5;
                   break;
               
             }
@@ -1607,7 +1607,7 @@ function trans(ty1, ty2) {
           break;
       case 7 : 
           if (typeof ty2 === "number") {
-            exit = 331;
+            exit = 8;
           }
           else {
             switch (ty2[0]) {
@@ -1617,25 +1617,25 @@ function trans(ty1, ty2) {
                           trans(ty1[1], ty2[1])
                         ];
               case 8 : 
-                  exit = 335;
+                  exit = 6;
                   break;
               case 9 : 
-                  exit = 333;
+                  exit = 7;
                   break;
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
-                  exit = 339;
+                  exit = 4;
                   break;
               case 14 : 
-                  exit = 337;
+                  exit = 5;
                   break;
               
             }
@@ -1663,19 +1663,19 @@ function trans(ty1, ty2) {
                           trans(ty1[2], ty2[2])
                         ];
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
-                  exit = 339;
+                  exit = 4;
                   break;
               case 14 : 
-                  exit = 337;
+                  exit = 5;
                   break;
               default:
                 throw [
@@ -1707,7 +1707,7 @@ function trans(ty1, ty2) {
           else {
             switch (ty2[0]) {
               case 8 : 
-                  exit = 335;
+                  exit = 6;
                   break;
               case 9 : 
                   var ty = trans(symm(ty1[2]), ty2[1]);
@@ -1721,19 +1721,19 @@ function trans(ty1, ty2) {
                           trans(ty1[3], ty2[3])
                         ];
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
-                  exit = 339;
+                  exit = 4;
                   break;
               case 14 : 
-                  exit = 337;
+                  exit = 5;
                   break;
               default:
                 throw [
@@ -1799,7 +1799,7 @@ function trans(ty1, ty2) {
           else {
             switch (ty2[0]) {
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
                   return [
@@ -1836,10 +1836,10 @@ function trans(ty1, ty2) {
           else {
             switch (ty2[0]) {
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
                   return [
@@ -1876,13 +1876,13 @@ function trans(ty1, ty2) {
           else {
             switch (ty2[0]) {
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
                   return [
@@ -1919,16 +1919,16 @@ function trans(ty1, ty2) {
           else {
             switch (ty2[0]) {
               case 10 : 
-                  exit = 345;
+                  exit = 1;
                   break;
               case 11 : 
-                  exit = 343;
+                  exit = 2;
                   break;
               case 12 : 
-                  exit = 341;
+                  exit = 3;
                   break;
               case 13 : 
-                  exit = 339;
+                  exit = 4;
                   break;
               case 14 : 
                   return [
@@ -1953,7 +1953,7 @@ function trans(ty1, ty2) {
     }
   }
   switch (exit) {
-    case 345 : 
+    case 1 : 
         throw [
               0,
               Caml_exceptions.Assert_failure,
@@ -1964,7 +1964,7 @@ function trans(ty1, ty2) {
                 21
               ]
             ];
-    case 343 : 
+    case 2 : 
         throw [
               0,
               Caml_exceptions.Assert_failure,
@@ -1975,7 +1975,7 @@ function trans(ty1, ty2) {
                 21
               ]
             ];
-    case 341 : 
+    case 3 : 
         throw [
               0,
               Caml_exceptions.Assert_failure,
@@ -1986,7 +1986,7 @@ function trans(ty1, ty2) {
                 19
               ]
             ];
-    case 339 : 
+    case 4 : 
         throw [
               0,
               Caml_exceptions.Assert_failure,
@@ -1997,7 +1997,7 @@ function trans(ty1, ty2) {
                 22
               ]
             ];
-    case 337 : 
+    case 5 : 
         throw [
               0,
               Caml_exceptions.Assert_failure,
@@ -2008,7 +2008,7 @@ function trans(ty1, ty2) {
                 30
               ]
             ];
-    case 335 : 
+    case 6 : 
         throw [
               0,
               Caml_exceptions.Assert_failure,
@@ -2019,7 +2019,7 @@ function trans(ty1, ty2) {
                 26
               ]
             ];
-    case 333 : 
+    case 7 : 
         throw [
               0,
               Caml_exceptions.Assert_failure,
@@ -2030,7 +2030,7 @@ function trans(ty1, ty2) {
                 28
               ]
             ];
-    case 331 : 
+    case 8 : 
         throw [
               0,
               Caml_exceptions.Assert_failure,
@@ -2334,7 +2334,7 @@ function type_format(fmt, fmtty) {
 }
 
 function type_format_gen(fmt, fmtty) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (typeof fmt === "number") {
     return [
             /* Fmt_fmtty_EBB */0,
@@ -2346,11 +2346,11 @@ function type_format_gen(fmt, fmtty) {
     switch (fmt[0]) {
       case 0 : 
           if (typeof fmtty === "number") {
-            exit = 293;
+            exit = 1;
           }
           else {
             if (fmtty[0]) {
-              exit = 293;
+              exit = 1;
             }
             else {
               var match = type_format_gen(fmt[1], fmtty[1]);
@@ -2367,11 +2367,11 @@ function type_format_gen(fmt, fmtty) {
           break;
       case 1 : 
           if (typeof fmtty === "number") {
-            exit = 293;
+            exit = 1;
           }
           else {
             if (fmtty[0]) {
-              exit = 293;
+              exit = 1;
             }
             else {
               var match$1 = type_format_gen(fmt[1], fmtty[1]);
@@ -2566,7 +2566,7 @@ function type_format_gen(fmt, fmtty) {
           break;
       case 9 : 
           if (typeof fmtty === "number") {
-            exit = 293;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 7) {
@@ -2581,7 +2581,7 @@ function type_format_gen(fmt, fmtty) {
                     ];
             }
             else {
-              exit = 293;
+              exit = 1;
             }
           }
           break;
@@ -2619,7 +2619,7 @@ function type_format_gen(fmt, fmtty) {
                 ];
       case 13 : 
           if (typeof fmtty === "number") {
-            exit = 293;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 8) {
@@ -2646,13 +2646,13 @@ function type_format_gen(fmt, fmtty) {
                     ];
             }
             else {
-              exit = 293;
+              exit = 1;
             }
           }
           break;
       case 14 : 
           if (typeof fmtty === "number") {
-            exit = 293;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 9) {
@@ -2679,13 +2679,13 @@ function type_format_gen(fmt, fmtty) {
                     ];
             }
             else {
-              exit = 293;
+              exit = 1;
             }
           }
           break;
       case 15 : 
           if (typeof fmtty === "number") {
-            exit = 293;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 10) {
@@ -2700,13 +2700,13 @@ function type_format_gen(fmt, fmtty) {
                     ];
             }
             else {
-              exit = 293;
+              exit = 1;
             }
           }
           break;
       case 16 : 
           if (typeof fmtty === "number") {
-            exit = 293;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 11) {
@@ -2721,7 +2721,7 @@ function type_format_gen(fmt, fmtty) {
                     ];
             }
             else {
-              exit = 293;
+              exit = 1;
             }
           }
           break;
@@ -2740,7 +2740,7 @@ function type_format_gen(fmt, fmtty) {
           return type_formatting_gen(fmt[1], fmt[2], fmtty);
       case 19 : 
           if (typeof fmtty === "number") {
-            exit = 293;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 13) {
@@ -2755,13 +2755,13 @@ function type_format_gen(fmt, fmtty) {
                     ];
             }
             else {
-              exit = 293;
+              exit = 1;
             }
           }
           break;
       case 20 : 
           if (typeof fmtty === "number") {
-            exit = 293;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 1) {
@@ -2778,13 +2778,13 @@ function type_format_gen(fmt, fmtty) {
                     ];
             }
             else {
-              exit = 293;
+              exit = 1;
             }
           }
           break;
       case 21 : 
           if (typeof fmtty === "number") {
-            exit = 293;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 2) {
@@ -2800,7 +2800,7 @@ function type_format_gen(fmt, fmtty) {
                     ];
             }
             else {
-              exit = 293;
+              exit = 1;
             }
           }
           break;
@@ -2808,12 +2808,12 @@ function type_format_gen(fmt, fmtty) {
           return type_ignored_param(fmt[1], fmt[2], fmtty);
       case 22 : 
       case 24 : 
-          exit = 293;
+          exit = 1;
           break;
       
     }
   }
-  if (exit === 293) {
+  if (exit === 1) {
     throw Type_mismatch;
   }
   
@@ -2950,7 +2950,7 @@ function type_ignored_param_one(ign, fmt, fmtty) {
 }
 
 function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (typeof sub_fmtty === "number") {
     return [
             /* Fmtty_fmt_EBB */0,
@@ -2962,11 +2962,11 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
     switch (sub_fmtty[0]) {
       case 0 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0]) {
-              exit = 297;
+              exit = 1;
             }
             else {
               var match = type_ignored_format_substitution(sub_fmtty[1], fmt, fmtty[1]);
@@ -2983,7 +2983,7 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
           break;
       case 1 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 1) {
@@ -2998,13 +2998,13 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 2 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 2) {
@@ -3019,13 +3019,13 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 3 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 3) {
@@ -3040,13 +3040,13 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 4 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 4) {
@@ -3061,13 +3061,13 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 5 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 5) {
@@ -3082,13 +3082,13 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 6 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 6) {
@@ -3103,13 +3103,13 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 7 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 7) {
@@ -3124,13 +3124,13 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 8 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 8) {
@@ -3156,13 +3156,13 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 9 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 9) {
@@ -3203,13 +3203,13 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 10 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 10) {
@@ -3224,13 +3224,13 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 11 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 11) {
@@ -3245,16 +3245,16 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 12 : 
-          exit = 297;
+          exit = 1;
           break;
       case 13 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 13) {
@@ -3269,13 +3269,13 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       case 14 : 
           if (typeof fmtty === "number") {
-            exit = 297;
+            exit = 1;
           }
           else {
             if (fmtty[0] === 14) {
@@ -3290,14 +3290,14 @@ function type_ignored_format_substitution(sub_fmtty, fmt, fmtty) {
                     ];
             }
             else {
-              exit = 297;
+              exit = 1;
             }
           }
           break;
       
     }
   }
-  if (exit === 297) {
+  if (exit === 1) {
     throw Type_mismatch;
   }
   
@@ -3350,19 +3350,19 @@ function fix_int_precision(prec, str) {
   var prec$1 = Pervasives.abs(prec);
   var len = str.length;
   var c = str.charCodeAt(0);
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (c >= 58) {
     if (c >= 71) {
       if (5 < (-97 + c >>> 0)) {
         return str;
       }
       else {
-        exit = 276;
+        exit = 2;
       }
     }
     else {
       if (c >= 65) {
-        exit = 276;
+        exit = 2;
       }
       else {
         return str;
@@ -3375,7 +3375,7 @@ function fix_int_precision(prec, str) {
         switch (-43 + c) {
           case 0 : 
           case 2 : 
-              exit = 275;
+              exit = 1;
               break;
           case 1 : 
           case 3 : 
@@ -3389,7 +3389,7 @@ function fix_int_precision(prec, str) {
                 return Bytes.unsafe_to_string(res);
               }
               else {
-                exit = 276;
+                exit = 2;
               }
               break;
           case 6 : 
@@ -3401,7 +3401,7 @@ function fix_int_precision(prec, str) {
           case 12 : 
           case 13 : 
           case 14 : 
-              exit = 276;
+              exit = 2;
               break;
           
         }
@@ -3411,11 +3411,11 @@ function fix_int_precision(prec, str) {
       }
     }
     else {
-      exit = 275;
+      exit = 1;
     }
   }
   switch (exit) {
-    case 275 : 
+    case 1 : 
         if (prec$1 + 1 > len) {
           var res$1 = Bytes.make(prec$1 + 1, /* "0" */48);
           res$1[0] = c;
@@ -3426,7 +3426,7 @@ function fix_int_precision(prec, str) {
           return str;
         }
         break;
-    case 276 : 
+    case 2 : 
         if (prec$1 > len) {
           var res$2 = Bytes.make(prec$1, /* "0" */48);
           $$String.blit(str, 0, res$2, prec$1 - len, len);
@@ -4374,7 +4374,7 @@ function make_custom(k, o, acc, rest, arity, f) {
 function output_acc(o, _acc) {
   while(/* true */1) {
     var acc = _acc;
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (typeof acc === "number") {
       return /* () */0;
     }
@@ -4399,11 +4399,11 @@ function output_acc(o, _acc) {
             break;
         case 2 : 
         case 4 : 
-            exit = 215;
+            exit = 1;
             break;
         case 3 : 
         case 5 : 
-            exit = 216;
+            exit = 2;
             break;
         case 6 : 
             output_acc(o, acc[1]);
@@ -4418,10 +4418,10 @@ function output_acc(o, _acc) {
       }
     }
     switch (exit) {
-      case 215 : 
+      case 1 : 
           output_acc(o, acc[1]);
           return Pervasives.output_string(o, acc[2]);
-      case 216 : 
+      case 2 : 
           output_acc(o, acc[1]);
           return Pervasives.output_char(o, acc[2]);
       
@@ -4432,7 +4432,7 @@ function output_acc(o, _acc) {
 function bufput_acc(b, _acc) {
   while(/* true */1) {
     var acc = _acc;
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (typeof acc === "number") {
       return /* () */0;
     }
@@ -4457,11 +4457,11 @@ function bufput_acc(b, _acc) {
             break;
         case 2 : 
         case 4 : 
-            exit = 210;
+            exit = 1;
             break;
         case 3 : 
         case 5 : 
-            exit = 211;
+            exit = 2;
             break;
         case 6 : 
             bufput_acc(b, acc[1]);
@@ -4476,10 +4476,10 @@ function bufput_acc(b, _acc) {
       }
     }
     switch (exit) {
-      case 210 : 
+      case 1 : 
           bufput_acc(b, acc[1]);
           return Buffer.add_string(b, acc[2]);
-      case 211 : 
+      case 2 : 
           bufput_acc(b, acc[1]);
           return Buffer.add_char(b, acc[2]);
       
@@ -4490,7 +4490,7 @@ function bufput_acc(b, _acc) {
 function strput_acc(b, _acc) {
   while(/* true */1) {
     var acc = _acc;
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (typeof acc === "number") {
       return /* () */0;
     }
@@ -4515,11 +4515,11 @@ function strput_acc(b, _acc) {
             break;
         case 2 : 
         case 4 : 
-            exit = 205;
+            exit = 1;
             break;
         case 3 : 
         case 5 : 
-            exit = 206;
+            exit = 2;
             break;
         case 6 : 
             strput_acc(b, acc[1]);
@@ -4534,10 +4534,10 @@ function strput_acc(b, _acc) {
       }
     }
     switch (exit) {
-      case 205 : 
+      case 1 : 
           strput_acc(b, acc[1]);
           return Buffer.add_string(b, acc[2]);
-      case 206 : 
+      case 2 : 
           strput_acc(b, acc[1]);
           return Buffer.add_char(b, acc[2]);
       
@@ -4626,13 +4626,13 @@ function open_box_of_string(str) {
         }
         else {
           var match = str.charCodeAt(j);
-          /* initialize */var exit = 0;
+          var exit = 0;
           if (match >= 48) {
             if (match >= 58) {
               return j;
             }
             else {
-              exit = 194;
+              exit = 1;
             }
           }
           else {
@@ -4640,10 +4640,10 @@ function open_box_of_string(str) {
               return j;
             }
             else {
-              exit = 194;
+              exit = 1;
             }
           }
-          if (exit === 194) {
+          if (exit === 1) {
             _j = j + 1;
           }
           
@@ -5004,10 +5004,10 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           unexpected_end_of_format(end_ind);
         }
         var match = str.charCodeAt(str_ind);
-        /* initialize */var exit = 0;
+        var exit = 0;
         var switcher = -32 + match;
         if (16 < (switcher >>> 0)) {
-          exit = 7;
+          exit = 1;
         }
         else {
           switch (switcher) {
@@ -5039,7 +5039,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             case 12 : 
             case 14 : 
             case 15 : 
-                exit = 7;
+                exit = 1;
                 break;
             case 16 : 
                 set_flag(str_ind, zero);
@@ -5048,7 +5048,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             
           }
         }
-        if (exit === 7) {
+        if (exit === 1) {
           return parse_padding(pct_ind, str_ind, end_ind, zero[1], minus[1], plus[1], sharp[1], space[1], ign);
         }
         
@@ -5068,10 +5068,10 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         minus !== 0 ? /* Left */0 : /* Right */1
       );
     var match = str.charCodeAt(str_ind);
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (match >= 48) {
       if (match >= 58) {
-        exit = 16;
+        exit = 1;
       }
       else {
         var match$1 = parse_positive(str_ind, end_ind, 0);
@@ -5084,7 +5084,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     }
     else {
       if (match !== 42) {
-        exit = 16;
+        exit = 1;
       }
       else {
         return parse_after_padding(pct_ind, str_ind + 1, end_ind, minus, plus, sharp, space, ign, [
@@ -5093,7 +5093,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                   ]);
       }
     }
-    if (exit === 16) {
+    if (exit === 1) {
       switch (padty) {
         case 0 : 
             if (!legacy_behavior$1) {
@@ -5132,10 +5132,10 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                 ]);
     };
     var symb = str.charCodeAt(str_ind);
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (symb >= 48) {
       if (symb >= 58) {
-        exit = 19;
+        exit = 2;
       }
       else {
         return parse_literal(minus, str_ind);
@@ -5148,30 +5148,30 @@ function fmt_ebb_of_string(legacy_behavior, str) {
               return parse_after_precision(pct_ind, str_ind + 1, end_ind, minus, plus, sharp, space, ign, pad, /* Arg_precision */1);
           case 1 : 
           case 3 : 
-              exit = 21;
+              exit = 1;
               break;
           case 2 : 
           case 4 : 
           case 5 : 
-              exit = 19;
+              exit = 2;
               break;
           
         }
       }
       else {
-        exit = 19;
+        exit = 2;
       }
     }
     switch (exit) {
-      case 21 : 
+      case 1 : 
           if (legacy_behavior$1) {
             return parse_literal(+(minus || symb === /* "-" */45), str_ind + 1);
           }
           else {
-            exit = 19;
+            exit = 2;
           }
           break;
-      case 19 : 
+      case 2 : 
           return legacy_behavior$1 ? parse_after_precision(pct_ind, str_ind, end_ind, minus, plus, sharp, space, ign, pad, [
                         /* Lit_precision */0,
                         0
@@ -5187,19 +5187,19 @@ function fmt_ebb_of_string(legacy_behavior, str) {
       return parse_conversion(pct_ind, str_ind + 1, end_ind, plus, sharp, space, ign, pad, prec, padprec, str.charCodeAt(str_ind));
     };
     if (typeof pad === "number") {
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (typeof prec === "number") {
         if (prec !== 0) {
-          exit = 24;
+          exit = 1;
         }
         else {
           return parse_conv(/* No_padding */0);
         }
       }
       else {
-        exit = 24;
+        exit = 1;
       }
-      if (exit === 24) {
+      if (exit === 1) {
         return minus !== 0 ? (
                   typeof prec === "number" ? parse_conv([
                           /* Arg_padding */1,
@@ -5345,9 +5345,9 @@ function fmt_ebb_of_string(legacy_behavior, str) {
               ];
     };
     var fmt_result;
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (symb >= 124) {
-      exit = 63;
+      exit = 7;
     }
     else {
       switch (symb) {
@@ -5400,7 +5400,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             break;
         case 37 : 
         case 64 : 
-            exit = 68;
+            exit = 5;
             break;
         case 67 : 
             var match$3 = parse(str_ind, end_ind);
@@ -5518,7 +5518,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         case 43 : 
         case 45 : 
         case 95 : 
-            exit = 69;
+            exit = 6;
             break;
         case 97 : 
             var match$9 = parse(str_ind, end_ind);
@@ -5532,7 +5532,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             break;
         case 66 : 
         case 98 : 
-            exit = 67;
+            exit = 4;
             break;
         case 99 : 
             var char_format = function (fmt_rest) {
@@ -5582,12 +5582,12 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         case 101 : 
         case 102 : 
         case 103 : 
-            exit = 66;
+            exit = 3;
             break;
         case 76 : 
         case 108 : 
         case 110 : 
-            exit = 65;
+            exit = 2;
             break;
         case 114 : 
             var match$12 = parse(str_ind, end_ind);
@@ -5654,7 +5654,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         case 111 : 
         case 117 : 
         case 120 : 
-            exit = 64;
+            exit = 1;
             break;
         case 0 : 
         case 1 : 
@@ -5743,7 +5743,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         case 119 : 
         case 121 : 
         case 122 : 
-            exit = 63;
+            exit = 7;
             break;
         case 123 : 
             var sub_end$1 = search_subformat_end(str_ind, end_ind, /* "}" */125);
@@ -5783,7 +5783,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
       }
     }
     switch (exit) {
-      case 64 : 
+      case 1 : 
           var iconv = compute_int_conv(pct_ind, str_ind, get_plus(/* () */0), get_sharp(/* () */0), get_space(/* () */0), symb);
           var match$18 = parse(str_ind, end_ind);
           var fmt_rest$9 = match$18[1];
@@ -5807,11 +5807,11 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             var match$19 = get_pad(/* () */0);
             var match$20 = get_prec(/* () */0);
             var pad$3;
-            /* initialize */var exit$1 = 0;
+            var exit$1 = 0;
             typeof match$20 === "number" ? (
-                match$20 !== 0 ? (exit$1 = 36) : (pad$3 = match$19)
-              ) : (exit$1 = 36);
-            if (exit$1 === 36) {
+                match$20 !== 0 ? (exit$1 = 9) : (pad$3 = match$19)
+              ) : (exit$1 = 9);
+            if (exit$1 === 9) {
               pad$3 = typeof match$19 === "number" ? /* No_padding */0 : (
                   match$19[0] ? (
                       match$19[1] >= 2 ? (
@@ -5844,7 +5844,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             ];
           }
           break;
-      case 65 : 
+      case 2 : 
           if (str_ind === end_ind || !is_int_base(str.charCodeAt(str_ind))) {
             var match$22 = parse(str_ind, end_ind);
             var fmt_rest$10 = match$22[1];
@@ -5875,10 +5875,10 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             }
           }
           else {
-            exit = 63;
+            exit = 7;
           }
           break;
-      case 66 : 
+      case 3 : 
           var fconv = compute_float_conv(pct_ind, str_ind, get_plus(/* () */0), get_space(/* () */0), symb);
           var match$23 = parse(str_ind, end_ind);
           var fmt_rest$11 = match$23[1];
@@ -5913,7 +5913,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             ];
           }
           break;
-      case 67 : 
+      case 4 : 
           var match$25 = parse(str_ind, end_ind);
           var fmt_rest$12 = match$25[1];
           fmt_result = get_ign(/* () */0) ? [
@@ -5931,7 +5931,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
               ]
             ];
           break;
-      case 68 : 
+      case 5 : 
           var match$26 = parse(str_ind, end_ind);
           fmt_result = [
             /* Fmt_EBB */0,
@@ -5942,7 +5942,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             ]
           ];
           break;
-      case 69 : 
+      case 6 : 
           fmt_result = failwith_message([
                   /* Format */0,
                   [
@@ -5986,10 +5986,10 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                   "invalid format %S: at character number %d, flag %C is only allowed after the '%%', before padding and precision"
                 ])(str, pct_ind, symb);
           break;
-      case 63 : 
+      case 7 : 
           if (symb >= 108) {
             if (symb >= 111) {
-              exit = 62;
+              exit = 8;
             }
             else {
               switch (-108 + symb) {
@@ -6028,7 +6028,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                     }
                     break;
                 case 1 : 
-                    exit = 62;
+                    exit = 8;
                     break;
                 case 2 : 
                     var iconv$2 = compute_int_conv(pct_ind, str_ind + 1, get_plus(/* () */0), get_sharp(/* () */0), get_space(/* () */0), str.charCodeAt(str_ind));
@@ -6070,7 +6070,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           }
           else {
             if (symb !== 76) {
-              exit = 62;
+              exit = 8;
             }
             else {
               var iconv$3 = compute_int_conv(pct_ind, str_ind + 1, get_plus(/* () */0), get_sharp(/* () */0), get_space(/* () */0), str.charCodeAt(str_ind));
@@ -6108,7 +6108,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             }
           }
           break;
-      case 62 : 
+      case 8 : 
           fmt_result = failwith_message([
                   /* Format */0,
                   [
@@ -6184,23 +6184,23 @@ function fmt_ebb_of_string(legacy_behavior, str) {
       
     }
     if (!ign_used[1] && ign) {
-      /* initialize */var exit$2 = 0;
+      var exit$2 = 0;
       exit$2 = symb >= 38 ? (
           symb !== 44 ? (
-              symb !== 64 ? 27 : 28
-            ) : 28
+              symb !== 64 ? 2 : 1
+            ) : 1
         ) : (
           symb !== 33 ? (
-              symb >= 37 ? 28 : 27
-            ) : 28
+              symb >= 37 ? 1 : 2
+            ) : 1
         );
       switch (exit$2) {
-        case 28 : 
+        case 1 : 
             if (!legacy_behavior$1) {
-              exit$2 = 27;
+              exit$2 = 2;
             }
             break;
-        case 27 : 
+        case 2 : 
             incompatible_flag(pct_ind, str_ind, symb, "'_'");
             break;
         
@@ -6221,19 +6221,19 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     }
     else {
       var c = str.charCodeAt(str_ind);
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (c >= 65) {
         if (c >= 94) {
           var switcher = -123 + c;
           if (2 < (switcher >>> 0)) {
-            exit = 91;
+            exit = 1;
           }
           else {
             switch (switcher) {
               case 0 : 
                   return parse_tag(/* true */1, str_ind + 1, end_ind);
               case 1 : 
-                  exit = 91;
+                  exit = 1;
                   break;
               case 2 : 
                   var match = parse(str_ind + 1, end_ind);
@@ -6255,7 +6255,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
               case 0 : 
                   return parse_tag(/* false */0, str_ind + 1, end_ind);
               case 1 : 
-                  exit = 91;
+                  exit = 1;
                   break;
               case 2 : 
                   var match$1 = parse(str_ind + 1, end_ind);
@@ -6271,7 +6271,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             }
           }
           else {
-            exit = 91;
+            exit = 1;
           }
         }
       }
@@ -6372,7 +6372,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
               case 26 : 
               case 29 : 
               case 30 : 
-                  exit = 91;
+                  exit = 1;
                   break;
               case 31 : 
                   var match$7 = parse(str_ind + 1, end_ind);
@@ -6398,7 +6398,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             }
           }
           else {
-            exit = 91;
+            exit = 1;
           }
         }
         else {
@@ -6413,7 +6413,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                 ];
         }
       }
-      if (exit === 91) {
+      if (exit === 1) {
         var match$10 = parse(str_ind + 1, end_ind);
         return [
                 /* Fmt_EBB */0,
@@ -6535,13 +6535,13 @@ function fmt_ebb_of_string(legacy_behavior, str) {
       }
       var str_ind_1 = parse_spaces(str_ind + 1, end_ind);
       var match$1 = str.charCodeAt(str_ind_1);
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (match$1 >= 48) {
         if (match$1 >= 58) {
           throw Caml_exceptions.Not_found;
         }
         else {
-          exit = 113;
+          exit = 1;
         }
       }
       else {
@@ -6549,10 +6549,10 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           throw Caml_exceptions.Not_found;
         }
         else {
-          exit = 113;
+          exit = 1;
         }
       }
-      if (exit === 113) {
+      if (exit === 1) {
         var match$2 = parse_integer(str_ind_1, end_ind);
         var width = match$2[2];
         var str_ind_3 = parse_spaces(match$2[1], end_ind);
@@ -6648,13 +6648,13 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     try {
       var str_ind_1 = parse_spaces(str_ind, end_ind);
       var match$1 = str.charCodeAt(str_ind_1);
-      /* initialize */var exit = 0;
+      var exit = 0;
       match$1 >= 48 ? (
-          match$1 >= 58 ? (match = /* None */0) : (exit = 123)
+          match$1 >= 58 ? (match = /* None */0) : (exit = 1)
         ) : (
-          match$1 !== 45 ? (match = /* None */0) : (exit = 123)
+          match$1 !== 45 ? (match = /* None */0) : (exit = 1)
         );
-      if (exit === 123) {
+      if (exit === 1) {
         var match$2 = parse_integer(str_ind_1, end_ind);
         var str_ind_3 = parse_spaces(match$2[1], end_ind);
         if (str.charCodeAt(str_ind_3) !== /* ">" */62) {
@@ -6810,11 +6810,11 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           unexpected_end_of_format(end_ind);
         }
         var c$prime = str.charCodeAt(str_ind);
-        /* initialize */var exit = 0;
+        var exit = 0;
         if (c$prime >= 46) {
           if (c$prime !== 64) {
             if (c$prime !== 93) {
-              exit = 132;
+              exit = 2;
             }
             else {
               add_char(c);
@@ -6822,7 +6822,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             }
           }
           else {
-            exit = 133;
+            exit = 1;
           }
         }
         else {
@@ -6831,24 +6831,24 @@ function fmt_ebb_of_string(legacy_behavior, str) {
               return parse_char_set_after_minus(str_ind + 1, end_ind, c);
             }
             else {
-              exit = 132;
+              exit = 2;
             }
           }
           else {
-            exit = 133;
+            exit = 1;
           }
         }
         switch (exit) {
-          case 133 : 
+          case 1 : 
               if (c === /* "%" */37) {
                 add_char(c$prime);
                 return parse_char_set_content(str_ind + 1, end_ind);
               }
               else {
-                exit = 132;
+                exit = 2;
               }
               break;
-          case 132 : 
+          case 2 : 
               if (c === /* "%" */37) {
                 fail_single_percent(str_ind);
               }
@@ -6873,19 +6873,19 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           unexpected_end_of_format(end_ind);
         }
         var c$prime$1 = str.charCodeAt(str_ind + 1);
-        /* initialize */var exit = 0;
+        var exit = 0;
         if (c$prime$1 !== 37) {
           if (c$prime$1 !== 64) {
             return fail_single_percent(str_ind);
           }
           else {
-            exit = 134;
+            exit = 1;
           }
         }
         else {
-          exit = 134;
+          exit = 1;
         }
-        if (exit === 134) {
+        if (exit === 1) {
           add_range(c, c$prime$1);
           return parse_char_set_content(str_ind + 2, end_ind);
         }
@@ -7115,11 +7115,11 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         }
         else {
           var match$1 = str.charCodeAt(str_ind + 1);
-          /* initialize */var exit = 0;
+          var exit = 0;
           if (match$1 >= 95) {
             if (match$1 >= 123) {
               if (match$1 >= 126) {
-                exit = 155;
+                exit = 1;
               }
               else {
                 switch (-123 + match$1) {
@@ -7128,7 +7128,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                       _str_ind = sub_end + 2;
                       break;
                   case 1 : 
-                      exit = 155;
+                      exit = 1;
                       break;
                   case 2 : 
                       return expected_character(str_ind + 1, "character ')'", /* "}" */125);
@@ -7138,7 +7138,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
             }
             else {
               if (match$1 >= 96) {
-                exit = 155;
+                exit = 1;
               }
               else {
                 if (str_ind + 2 === end_ind) {
@@ -7164,7 +7164,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           else {
             if (match$1 !== 40) {
               if (match$1 !== 41) {
-                exit = 155;
+                exit = 1;
               }
               else {
                 return expected_character(str_ind + 1, "character '}'", /* ")" */41);
@@ -7175,7 +7175,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
               _str_ind = sub_end$3 + 2;
             }
           }
-          if (exit === 155) {
+          if (exit === 1) {
             _str_ind = str_ind + 2;
           }
           
@@ -7230,17 +7230,17 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     }
   };
   var counter_of_char = function (symb) {
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (symb >= 108) {
       if (symb >= 111) {
-        exit = 159;
+        exit = 1;
       }
       else {
         switch (-108 + symb) {
           case 0 : 
               return /* Line_counter */0;
           case 1 : 
-              exit = 159;
+              exit = 1;
               break;
           case 2 : 
               return /* Char_counter */1;
@@ -7250,13 +7250,13 @@ function fmt_ebb_of_string(legacy_behavior, str) {
     }
     else {
       if (symb !== 76) {
-        exit = 159;
+        exit = 1;
       }
       else {
         return /* Token_counter */2;
       }
     }
-    if (exit === 159) {
+    if (exit === 1) {
       throw [
             0,
             Caml_exceptions.Assert_failure,
@@ -7275,19 +7275,19 @@ function fmt_ebb_of_string(legacy_behavior, str) {
       var space = _space;
       var sharp = _sharp;
       var plus = _plus;
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (plus !== 0) {
         if (sharp !== 0) {
-          exit = 161;
+          exit = 1;
         }
         else {
           if (space !== 0) {
-            exit = 160;
+            exit = 2;
           }
           else {
             if (symb !== 100) {
               if (symb !== 105) {
-                exit = 160;
+                exit = 2;
               }
               else {
                 return /* Int_pi */4;
@@ -7302,13 +7302,13 @@ function fmt_ebb_of_string(legacy_behavior, str) {
       else {
         if (sharp !== 0) {
           if (space !== 0) {
-            exit = 161;
+            exit = 1;
           }
           else {
             if (symb !== 88) {
               if (symb !== 111) {
                 if (symb !== 120) {
-                  exit = 161;
+                  exit = 1;
                 }
                 else {
                   return /* Int_Cx */7;
@@ -7327,7 +7327,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           if (space !== 0) {
             if (symb !== 100) {
               if (symb !== 105) {
-                exit = 160;
+                exit = 2;
               }
               else {
                 return /* Int_si */5;
@@ -7340,7 +7340,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           else {
             var switcher = -88 + symb;
             if (32 < (switcher >>> 0)) {
-              exit = 160;
+              exit = 2;
             }
             else {
               switch (switcher) {
@@ -7381,7 +7381,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                 case 28 : 
                 case 30 : 
                 case 31 : 
-                    exit = 160;
+                    exit = 2;
                     break;
                 case 32 : 
                     return /* Int_x */6;
@@ -7392,11 +7392,11 @@ function fmt_ebb_of_string(legacy_behavior, str) {
         }
       }
       switch (exit) {
-        case 161 : 
-            /* initialize */var exit$1 = 0;
+        case 1 : 
+            var exit$1 = 0;
             var switcher$1 = -88 + symb;
             if (32 < (switcher$1 >>> 0)) {
-              exit = 160;
+              exit = 2;
             }
             else {
               switch (switcher$1) {
@@ -7405,7 +7405,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                       return /* Int_CX */9;
                     }
                     else {
-                      exit = 160;
+                      exit = 2;
                     }
                     break;
                 case 23 : 
@@ -7413,13 +7413,13 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                       return /* Int_Co */11;
                     }
                     else {
-                      exit = 160;
+                      exit = 2;
                     }
                     break;
                 case 12 : 
                 case 17 : 
                 case 29 : 
-                    exit$1 = 163;
+                    exit$1 = 3;
                     break;
                 case 1 : 
                 case 2 : 
@@ -7448,20 +7448,20 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                 case 28 : 
                 case 30 : 
                 case 31 : 
-                    exit = 160;
+                    exit = 2;
                     break;
                 case 32 : 
                     if (legacy_behavior$1) {
                       return /* Int_Cx */7;
                     }
                     else {
-                      exit = 160;
+                      exit = 2;
                     }
                     break;
                 
               }
             }
-            if (exit$1 === 163) {
+            if (exit$1 === 3) {
               if (legacy_behavior$1) {
                 _sharp = /* false */0;
               }
@@ -7470,7 +7470,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
               }
             }
             break;
-        case 160 : 
+        case 2 : 
             if (plus !== 0) {
               if (space !== 0) {
                 if (legacy_behavior$1) {
@@ -7530,11 +7530,11 @@ function fmt_ebb_of_string(legacy_behavior, str) {
           }
         }
         else {
-          /* initialize */var exit = 0;
+          var exit = 0;
           if (symb >= 72) {
             var switcher = -101 + symb;
             if (2 < (switcher >>> 0)) {
-              exit = 164;
+              exit = 1;
             }
             else {
               switch (switcher) {
@@ -7554,7 +7554,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                 case 0 : 
                     return /* Float_pE */7;
                 case 1 : 
-                    exit = 164;
+                    exit = 1;
                     break;
                 case 2 : 
                     return /* Float_pG */13;
@@ -7562,10 +7562,10 @@ function fmt_ebb_of_string(legacy_behavior, str) {
               }
             }
             else {
-              exit = 164;
+              exit = 1;
             }
           }
-          if (exit === 164) {
+          if (exit === 1) {
             if (legacy_behavior$1) {
               _plus = /* false */0;
             }
@@ -7578,11 +7578,11 @@ function fmt_ebb_of_string(legacy_behavior, str) {
       }
       else {
         if (space !== 0) {
-          /* initialize */var exit$1 = 0;
+          var exit$1 = 0;
           if (symb >= 72) {
             var switcher$1 = -101 + symb;
             if (2 < (switcher$1 >>> 0)) {
-              exit$1 = 165;
+              exit$1 = 1;
             }
             else {
               switch (switcher$1) {
@@ -7602,7 +7602,7 @@ function fmt_ebb_of_string(legacy_behavior, str) {
                 case 0 : 
                     return /* Float_sE */8;
                 case 1 : 
-                    exit$1 = 165;
+                    exit$1 = 1;
                     break;
                 case 2 : 
                     return /* Float_sG */14;
@@ -7610,10 +7610,10 @@ function fmt_ebb_of_string(legacy_behavior, str) {
               }
             }
             else {
-              exit$1 = 165;
+              exit$1 = 1;
             }
           }
-          if (exit$1 === 165) {
+          if (exit$1 === 1) {
             if (legacy_behavior$1) {
               _space = /* false */0;
             }

--- a/jscomp/stdlib/char.js
+++ b/jscomp/stdlib/char.js
@@ -8,11 +8,11 @@ function chr(n) {
 }
 
 function escaped(c) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (c !== 39) {
     if (c !== 92) {
       if (c >= 14) {
-        exit = 5;
+        exit = 1;
       }
       else {
         switch (c) {
@@ -32,7 +32,7 @@ function escaped(c) {
           case 7 : 
           case 11 : 
           case 12 : 
-              exit = 5;
+              exit = 1;
               break;
           case 13 : 
               return "\\r";
@@ -47,7 +47,7 @@ function escaped(c) {
   else {
     return "\\'";
   }
-  if (exit === 5) {
+  if (exit === 1) {
     if (Caml_string.caml_is_printable(c)) {
       return Caml_string.caml_string_of_char_array(/* array */[c]);
     }

--- a/jscomp/stdlib/digest.js
+++ b/jscomp/stdlib/digest.js
@@ -25,17 +25,17 @@ function subbytes(b, ofs, len) {
 
 function file(filename) {
   var ic = Pervasives.open_in_bin(filename);
-  /* initialize */var exit = 0;
+  var exit = 0;
   var d;
   try {
     d = Caml_primitive.caml_md5_chan(ic, -1);
-    exit = -1;
+    exit = 1;
   }
   catch (e){
     Pervasives.close_in(ic);
     throw e;
   }
-  if (exit === -1) {
+  if (exit === 1) {
     Pervasives.close_in(ic);
     return d;
   }
@@ -75,11 +75,11 @@ function from_hex(s) {
         ];
   }
   var digit = function (c) {
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (c >= 65) {
       if (c >= 97) {
         if (c >= 103) {
-          exit = 6;
+          exit = 1;
         }
         else {
           return c - /* "a" */97 + 10;
@@ -87,7 +87,7 @@ function from_hex(s) {
       }
       else {
         if (c >= 71) {
-          exit = 6;
+          exit = 1;
         }
         else {
           return c - /* "A" */65 + 10;
@@ -96,13 +96,13 @@ function from_hex(s) {
     }
     else {
       if (9 < (-48 + c >>> 0)) {
-        exit = 6;
+        exit = 1;
       }
       else {
         return c - /* "0" */48;
       }
     }
-    if (exit === 6) {
+    if (exit === 1) {
       throw [
             0,
             Caml_exceptions.Invalid_argument,

--- a/jscomp/stdlib/format.js
+++ b/jscomp/stdlib/format.js
@@ -404,7 +404,7 @@ function set_size(state, ty) {
       return clear_scan_stack(state);
     }
     else {
-      /* initialize */var exit = 0;
+      var exit = 0;
       var $js = queue_elem[2];
       if (typeof $js === "number") {
         return /* () */0;
@@ -413,7 +413,7 @@ function set_size(state, ty) {
         switch ($js[0]) {
           case 1 : 
           case 2 : 
-              exit = 193;
+              exit = 1;
               break;
           case 3 : 
               return !ty ? (queue_elem[1] = state[13] + size, state[1] = t, /* () */0) : 0;
@@ -421,7 +421,7 @@ function set_size(state, ty) {
             return /* () */0;
         }
       }
-      if (exit === 193) {
+      if (exit === 1) {
         return ty ? (queue_elem[1] = state[13] + size, state[1] = t, /* () */0) : 0;
       }
       
@@ -1316,7 +1316,7 @@ function output_formatting_lit(ppf, fmting_lit) {
 }
 
 function output_acc(ppf, acc) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   var p;
   var size;
   var s;
@@ -1349,138 +1349,138 @@ function output_acc(ppf, acc) {
           break;
       case 2 : 
           var p$5 = acc[1];
-          /* initialize */var exit$1 = 0;
+          var exit$1 = 0;
           if (typeof p$5 === "number") {
-            exit$1 = 36;
+            exit$1 = 5;
           }
           else {
             if (p$5[0]) {
-              exit$1 = 36;
+              exit$1 = 5;
             }
             else {
               var match$2 = p$5[2];
               if (typeof match$2 === "number") {
-                exit$1 = 36;
+                exit$1 = 5;
               }
               else {
                 if (match$2[0] === 1) {
                   p = p$5[1];
                   size = match$2[2];
                   s = acc[2];
-                  exit = 32;
+                  exit = 1;
                 }
                 else {
-                  exit$1 = 36;
+                  exit$1 = 5;
                 }
               }
             }
           }
-          if (exit$1 === 36) {
+          if (exit$1 === 5) {
             p$2 = p$5;
             s$1 = acc[2];
-            exit = 34;
+            exit = 3;
           }
           break;
       case 3 : 
           var p$6 = acc[1];
-          /* initialize */var exit$2 = 0;
+          var exit$2 = 0;
           if (typeof p$6 === "number") {
-            exit$2 = 38;
+            exit$2 = 5;
           }
           else {
             if (p$6[0]) {
-              exit$2 = 38;
+              exit$2 = 5;
             }
             else {
               var match$3 = p$6[2];
               if (typeof match$3 === "number") {
-                exit$2 = 38;
+                exit$2 = 5;
               }
               else {
                 if (match$3[0] === 1) {
                   p$1 = p$6[1];
                   size$1 = match$3[2];
                   c = acc[2];
-                  exit = 33;
+                  exit = 2;
                 }
                 else {
-                  exit$2 = 38;
+                  exit$2 = 5;
                 }
               }
             }
           }
-          if (exit$2 === 38) {
+          if (exit$2 === 5) {
             p$3 = p$6;
             c$1 = acc[2];
-            exit = 35;
+            exit = 4;
           }
           break;
       case 4 : 
           var p$7 = acc[1];
-          /* initialize */var exit$3 = 0;
+          var exit$3 = 0;
           if (typeof p$7 === "number") {
-            exit$3 = 37;
+            exit$3 = 5;
           }
           else {
             if (p$7[0]) {
-              exit$3 = 37;
+              exit$3 = 5;
             }
             else {
               var match$4 = p$7[2];
               if (typeof match$4 === "number") {
-                exit$3 = 37;
+                exit$3 = 5;
               }
               else {
                 if (match$4[0] === 1) {
                   p = p$7[1];
                   size = match$4[2];
                   s = acc[2];
-                  exit = 32;
+                  exit = 1;
                 }
                 else {
-                  exit$3 = 37;
+                  exit$3 = 5;
                 }
               }
             }
           }
-          if (exit$3 === 37) {
+          if (exit$3 === 5) {
             p$2 = p$7;
             s$1 = acc[2];
-            exit = 34;
+            exit = 3;
           }
           break;
       case 5 : 
           var p$8 = acc[1];
-          /* initialize */var exit$4 = 0;
+          var exit$4 = 0;
           if (typeof p$8 === "number") {
-            exit$4 = 39;
+            exit$4 = 5;
           }
           else {
             if (p$8[0]) {
-              exit$4 = 39;
+              exit$4 = 5;
             }
             else {
               var match$5 = p$8[2];
               if (typeof match$5 === "number") {
-                exit$4 = 39;
+                exit$4 = 5;
               }
               else {
                 if (match$5[0] === 1) {
                   p$1 = p$8[1];
                   size$1 = match$5[2];
                   c = acc[2];
-                  exit = 33;
+                  exit = 2;
                 }
                 else {
-                  exit$4 = 39;
+                  exit$4 = 5;
                 }
               }
             }
           }
-          if (exit$4 === 39) {
+          if (exit$4 === 5) {
             p$3 = p$8;
             c$1 = acc[2];
-            exit = 35;
+            exit = 4;
           }
           break;
       case 6 : 
@@ -1496,16 +1496,16 @@ function output_acc(ppf, acc) {
     }
   }
   switch (exit) {
-    case 32 : 
+    case 1 : 
         output_acc(ppf, p);
         return pp_print_as_size(ppf, size, s);
-    case 33 : 
+    case 2 : 
         output_acc(ppf, p$1);
         return pp_print_as_size(ppf, size$1, $$String.make(1, c));
-    case 34 : 
+    case 3 : 
         output_acc(ppf, p$2);
         return pp_print_string(ppf, s$1);
-    case 35 : 
+    case 4 : 
         output_acc(ppf, p$3);
         return pp_print_char(ppf, c$1);
     
@@ -1513,7 +1513,7 @@ function output_acc(ppf, acc) {
 }
 
 function strput_acc(ppf, acc) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   var p;
   var size;
   var s;
@@ -1546,154 +1546,154 @@ function strput_acc(ppf, acc) {
           break;
       case 2 : 
           var p$5 = acc[1];
-          /* initialize */var exit$1 = 0;
+          var exit$1 = 0;
           if (typeof p$5 === "number") {
-            exit$1 = 26;
+            exit$1 = 5;
           }
           else {
             if (p$5[0]) {
-              exit$1 = 26;
+              exit$1 = 5;
             }
             else {
               var match$2 = p$5[2];
               if (typeof match$2 === "number") {
-                exit$1 = 26;
+                exit$1 = 5;
               }
               else {
                 if (match$2[0] === 1) {
                   p = p$5[1];
                   size = match$2[2];
                   s = acc[2];
-                  exit = 21;
+                  exit = 1;
                 }
                 else {
-                  exit$1 = 26;
+                  exit$1 = 5;
                 }
               }
             }
           }
-          if (exit$1 === 26) {
+          if (exit$1 === 5) {
             p$2 = p$5;
             s$1 = acc[2];
-            exit = 23;
+            exit = 3;
           }
           break;
       case 3 : 
           var p$6 = acc[1];
-          /* initialize */var exit$2 = 0;
+          var exit$2 = 0;
           if (typeof p$6 === "number") {
-            exit$2 = 28;
+            exit$2 = 5;
           }
           else {
             if (p$6[0]) {
-              exit$2 = 28;
+              exit$2 = 5;
             }
             else {
               var match$3 = p$6[2];
               if (typeof match$3 === "number") {
-                exit$2 = 28;
+                exit$2 = 5;
               }
               else {
                 if (match$3[0] === 1) {
                   p$1 = p$6[1];
                   size$1 = match$3[2];
                   c = acc[2];
-                  exit = 22;
+                  exit = 2;
                 }
                 else {
-                  exit$2 = 28;
+                  exit$2 = 5;
                 }
               }
             }
           }
-          if (exit$2 === 28) {
+          if (exit$2 === 5) {
             p$3 = p$6;
             c$1 = acc[2];
-            exit = 24;
+            exit = 4;
           }
           break;
       case 4 : 
           var p$7 = acc[1];
-          /* initialize */var exit$3 = 0;
+          var exit$3 = 0;
           if (typeof p$7 === "number") {
-            exit$3 = 27;
+            exit$3 = 5;
           }
           else {
             if (p$7[0]) {
-              exit$3 = 27;
+              exit$3 = 5;
             }
             else {
               var match$4 = p$7[2];
               if (typeof match$4 === "number") {
-                exit$3 = 27;
+                exit$3 = 5;
               }
               else {
                 if (match$4[0] === 1) {
                   p = p$7[1];
                   size = match$4[2];
                   s = acc[2];
-                  exit = 21;
+                  exit = 1;
                 }
                 else {
-                  exit$3 = 27;
+                  exit$3 = 5;
                 }
               }
             }
           }
-          if (exit$3 === 27) {
+          if (exit$3 === 5) {
             p$2 = p$7;
             s$1 = acc[2];
-            exit = 23;
+            exit = 3;
           }
           break;
       case 5 : 
           var p$8 = acc[1];
-          /* initialize */var exit$4 = 0;
+          var exit$4 = 0;
           if (typeof p$8 === "number") {
-            exit$4 = 29;
+            exit$4 = 5;
           }
           else {
             if (p$8[0]) {
-              exit$4 = 29;
+              exit$4 = 5;
             }
             else {
               var match$5 = p$8[2];
               if (typeof match$5 === "number") {
-                exit$4 = 29;
+                exit$4 = 5;
               }
               else {
                 if (match$5[0] === 1) {
                   p$1 = p$8[1];
                   size$1 = match$5[2];
                   c = acc[2];
-                  exit = 22;
+                  exit = 2;
                 }
                 else {
-                  exit$4 = 29;
+                  exit$4 = 5;
                 }
               }
             }
           }
-          if (exit$4 === 29) {
+          if (exit$4 === 5) {
             p$3 = p$8;
             c$1 = acc[2];
-            exit = 24;
+            exit = 4;
           }
           break;
       case 6 : 
           var p$9 = acc[1];
-          /* initialize */var exit$5 = 0;
+          var exit$5 = 0;
           if (typeof p$9 === "number") {
-            exit$5 = 25;
+            exit$5 = 5;
           }
           else {
             if (p$9[0]) {
-              exit$5 = 25;
+              exit$5 = 5;
             }
             else {
               var match$6 = p$9[2];
               if (typeof match$6 === "number") {
-                exit$5 = 25;
+                exit$5 = 5;
               }
               else {
                 if (match$6[0] === 1) {
@@ -1701,12 +1701,12 @@ function strput_acc(ppf, acc) {
                   return pp_print_as_size(ppf, match$6[2], acc[2](/* () */0));
                 }
                 else {
-                  exit$5 = 25;
+                  exit$5 = 5;
                 }
               }
             }
           }
-          if (exit$5 === 25) {
+          if (exit$5 === 5) {
             strput_acc(ppf, p$9);
             return pp_print_string(ppf, acc[2](/* () */0));
           }
@@ -1721,16 +1721,16 @@ function strput_acc(ppf, acc) {
     }
   }
   switch (exit) {
-    case 21 : 
+    case 1 : 
         strput_acc(ppf, p);
         return pp_print_as_size(ppf, size, s);
-    case 22 : 
+    case 2 : 
         strput_acc(ppf, p$1);
         return pp_print_as_size(ppf, size$1, $$String.make(1, c));
-    case 23 : 
+    case 3 : 
         strput_acc(ppf, p$2);
         return pp_print_string(ppf, s$1);
-    case 24 : 
+    case 4 : 
         strput_acc(ppf, p$3);
         return pp_print_char(ppf, c$1);
     

--- a/jscomp/stdlib/genlex.js
+++ b/jscomp/stdlib/genlex.js
@@ -91,27 +91,27 @@ function make_lexer(keywords) {
       var match = Stream.peek(strm__);
       if (match) {
         var c = match[1];
-        /* initialize */var exit = 0;
+        var exit = 0;
         if (c < 124) {
           var switcher = -65 + c;
           if (!(57 < (switcher >>> 0))) {
             var switcher$1 = -26 + switcher;
             if (5 < (switcher$1 >>> 0)) {
-              exit = 10;
+              exit = 3;
             }
             else {
               switch (switcher$1) {
                 case 1 : 
                 case 3 : 
-                    exit = 11;
+                    exit = 4;
                     break;
                 case 4 : 
-                    exit = 10;
+                    exit = 3;
                     break;
                 case 0 : 
                 case 2 : 
                 case 5 : 
-                    exit = 13;
+                    exit = 1;
                     break;
                 
               }
@@ -119,7 +119,7 @@ function make_lexer(keywords) {
           }
           else {
             if (switcher >= 58) {
-              exit = 13;
+              exit = 1;
             }
             else {
               switch (65 + switcher) {
@@ -129,7 +129,7 @@ function make_lexer(keywords) {
                 case 13 : 
                 case 26 : 
                 case 32 : 
-                    exit = 9;
+                    exit = 2;
                     break;
                 case 34 : 
                     Stream.junk(strm__);
@@ -160,10 +160,10 @@ function make_lexer(keywords) {
                       }
                     }
                     var match$1 = Stream.peek(strm__);
-                    /* initialize */var exit$1 = 0;
+                    var exit$1 = 0;
                     if (match$1) {
                       if (match$1[1] !== 39) {
-                        exit$1 = 4;
+                        exit$1 = 6;
                       }
                       else {
                         Stream.junk(strm__);
@@ -177,9 +177,9 @@ function make_lexer(keywords) {
                       }
                     }
                     else {
-                      exit$1 = 4;
+                      exit$1 = 6;
                     }
-                    if (exit$1 === 4) {
+                    if (exit$1 === 6) {
                       throw [
                             0,
                             Stream.$$Error,
@@ -203,7 +203,7 @@ function make_lexer(keywords) {
                 case 55 : 
                 case 56 : 
                 case 57 : 
-                    exit = 12;
+                    exit = 5;
                     break;
                 case 0 : 
                 case 1 : 
@@ -236,7 +236,7 @@ function make_lexer(keywords) {
                 case 44 : 
                 case 46 : 
                 case 59 : 
-                    exit = 13;
+                    exit = 1;
                     break;
                 case 33 : 
                 case 35 : 
@@ -252,7 +252,7 @@ function make_lexer(keywords) {
                 case 62 : 
                 case 63 : 
                 case 64 : 
-                    exit = 11;
+                    exit = 4;
                     break;
                 
               }
@@ -261,32 +261,32 @@ function make_lexer(keywords) {
         }
         else {
           exit = c >= 127 ? (
-              c >= 192 ? 10 : 13
+              c >= 192 ? 3 : 1
             ) : (
-              c !== 125 ? 11 : 13
+              c !== 125 ? 4 : 1
             );
         }
         switch (exit) {
-          case 13 : 
+          case 1 : 
               Stream.junk(strm__);
               return [
                       /* Some */0,
                       keyword_or_error(c)
                     ];
-          case 9 : 
+          case 2 : 
               Stream.junk(strm__);
               break;
-          case 10 : 
+          case 3 : 
               Stream.junk(strm__);
               reset_buffer(/* () */0);
               store(c);
               return ident(strm__);
-          case 11 : 
+          case 4 : 
               Stream.junk(strm__);
               reset_buffer(/* () */0);
               store(c);
               return ident2(strm__);
-          case 12 : 
+          case 5 : 
               Stream.junk(strm__);
               reset_buffer(/* () */0);
               store(c);
@@ -302,35 +302,35 @@ function make_lexer(keywords) {
   var ident = function (strm__) {
     while(/* true */1) {
       var match = Stream.peek(strm__);
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (match) {
         var c = match[1];
-        /* initialize */var exit$1 = 0;
+        var exit$1 = 0;
         if (c >= 91) {
           var switcher = -95 + c;
           27 < (switcher >>> 0) ? (
-              switcher >= 97 ? (exit$1 = 16) : (exit = 15)
+              switcher >= 97 ? (exit$1 = 2) : (exit = 1)
             ) : (
-              switcher !== 1 ? (exit$1 = 16) : (exit = 15)
+              switcher !== 1 ? (exit$1 = 2) : (exit = 1)
             );
         }
         else {
           c >= 48 ? (
-              6 < (-58 + c >>> 0) ? (exit$1 = 16) : (exit = 15)
+              6 < (-58 + c >>> 0) ? (exit$1 = 2) : (exit = 1)
             ) : (
-              c !== 39 ? (exit = 15) : (exit$1 = 16)
+              c !== 39 ? (exit = 1) : (exit$1 = 2)
             );
         }
-        if (exit$1 === 16) {
+        if (exit$1 === 2) {
           Stream.junk(strm__);
           store(c);
         }
         
       }
       else {
-        exit = 15;
+        exit = 1;
       }
-      if (exit === 15) {
+      if (exit === 1) {
         return [
                 /* Some */0,
                 ident_or_keyword(get_string(/* () */0))
@@ -342,21 +342,21 @@ function make_lexer(keywords) {
   var ident2 = function (strm__) {
     while(/* true */1) {
       var match = Stream.peek(strm__);
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (match) {
         var c = match[1];
-        /* initialize */var exit$1 = 0;
+        var exit$1 = 0;
         if (c >= 94) {
           var switcher = -95 + c;
           30 < (switcher >>> 0) ? (
-              switcher >= 32 ? (exit = 18) : (exit$1 = 19)
+              switcher >= 32 ? (exit = 1) : (exit$1 = 2)
             ) : (
-              switcher !== 29 ? (exit = 18) : (exit$1 = 19)
+              switcher !== 29 ? (exit = 1) : (exit$1 = 2)
             );
         }
         else {
           if (c >= 65) {
-            c !== 92 ? (exit = 18) : (exit$1 = 19);
+            c !== 92 ? (exit = 1) : (exit$1 = 2);
           }
           else {
             if (c >= 33) {
@@ -378,7 +378,7 @@ function make_lexer(keywords) {
                 case 23 : 
                 case 24 : 
                 case 26 : 
-                    exit = 18;
+                    exit = 1;
                     break;
                 case 0 : 
                 case 2 : 
@@ -395,26 +395,26 @@ function make_lexer(keywords) {
                 case 29 : 
                 case 30 : 
                 case 31 : 
-                    exit$1 = 19;
+                    exit$1 = 2;
                     break;
                 
               }
             }
             else {
-              exit = 18;
+              exit = 1;
             }
           }
         }
-        if (exit$1 === 19) {
+        if (exit$1 === 2) {
           Stream.junk(strm__);
           store(c);
         }
         
       }
       else {
-        exit = 18;
+        exit = 1;
       }
-      if (exit === 18) {
+      if (exit === 1) {
         return [
                 /* Some */0,
                 ident_or_keyword(get_string(/* () */0))
@@ -425,11 +425,11 @@ function make_lexer(keywords) {
   };
   var neg_number = function (strm__) {
     var match = Stream.peek(strm__);
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (match) {
       var c = match[1];
       if (9 < (-48 + c >>> 0)) {
-        exit = 22;
+        exit = 1;
       }
       else {
         Stream.junk(strm__);
@@ -440,9 +440,9 @@ function make_lexer(keywords) {
       }
     }
     else {
-      exit = 22;
+      exit = 1;
     }
-    if (exit === 22) {
+    if (exit === 1) {
       reset_buffer(/* () */0);
       store(/* "-" */45);
       return ident2(strm__);
@@ -452,14 +452,14 @@ function make_lexer(keywords) {
   var number = function (strm__) {
     while(/* true */1) {
       var match = Stream.peek(strm__);
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (match) {
         var c = match[1];
-        /* initialize */var exit$1 = 0;
+        var exit$1 = 0;
         if (c >= 58) {
           c !== 69 ? (
-              c !== 101 ? (exit = 27) : (exit$1 = 29)
-            ) : (exit$1 = 29);
+              c !== 101 ? (exit = 1) : (exit$1 = 2)
+            ) : (exit$1 = 2);
         }
         else {
           if (c !== 46) {
@@ -468,7 +468,7 @@ function make_lexer(keywords) {
               store(c);
             }
             else {
-              exit = 27;
+              exit = 1;
             }
           }
           else {
@@ -477,7 +477,7 @@ function make_lexer(keywords) {
             return decimal_part(strm__);
           }
         }
-        if (exit$1 === 29) {
+        if (exit$1 === 2) {
           Stream.junk(strm__);
           store(/* "E" */69);
           return exponent_part(strm__);
@@ -485,9 +485,9 @@ function make_lexer(keywords) {
         
       }
       else {
-        exit = 27;
+        exit = 1;
       }
-      if (exit === 27) {
+      if (exit === 1) {
         return [
                 /* Some */0,
                 [
@@ -502,13 +502,13 @@ function make_lexer(keywords) {
   var decimal_part = function (strm__) {
     while(/* true */1) {
       var match = Stream.peek(strm__);
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (match) {
         var c = match[1];
         var switcher = -69 + c;
         if (32 < (switcher >>> 0)) {
           if (9 < (21 + switcher >>> 0)) {
-            exit = 32;
+            exit = 1;
           }
           else {
             Stream.junk(strm__);
@@ -522,14 +522,14 @@ function make_lexer(keywords) {
             return exponent_part(strm__);
           }
           else {
-            exit = 32;
+            exit = 1;
           }
         }
       }
       else {
-        exit = 32;
+        exit = 1;
       }
-      if (exit === 32) {
+      if (exit === 1) {
         return [
                 /* Some */0,
                 [
@@ -545,19 +545,19 @@ function make_lexer(keywords) {
     var match = Stream.peek(strm__);
     if (match) {
       var c = match[1];
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (c !== 43) {
         if (c !== 45) {
           return end_exponent_part(strm__);
         }
         else {
-          exit = 37;
+          exit = 1;
         }
       }
       else {
-        exit = 37;
+        exit = 1;
       }
-      if (exit === 37) {
+      if (exit === 1) {
         Stream.junk(strm__);
         store(c);
         return end_exponent_part(strm__);
@@ -571,11 +571,11 @@ function make_lexer(keywords) {
   var end_exponent_part = function (strm__) {
     while(/* true */1) {
       var match = Stream.peek(strm__);
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (match) {
         var c = match[1];
         if (9 < (-48 + c >>> 0)) {
-          exit = 39;
+          exit = 1;
         }
         else {
           Stream.junk(strm__);
@@ -583,9 +583,9 @@ function make_lexer(keywords) {
         }
       }
       else {
-        exit = 39;
+        exit = 1;
       }
-      if (exit === 39) {
+      if (exit === 1) {
         return [
                 /* Some */0,
                 [
@@ -673,11 +673,11 @@ function make_lexer(keywords) {
     var match = Stream.peek(strm__);
     if (match) {
       var c1 = match[1];
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (c1 >= 58) {
         var switcher = -110 + c1;
         if (6 < (switcher >>> 0)) {
-          exit = 56;
+          exit = 1;
         }
         else {
           switch (switcher) {
@@ -691,7 +691,7 @@ function make_lexer(keywords) {
             case 2 : 
             case 3 : 
             case 5 : 
-                exit = 56;
+                exit = 1;
                 break;
             case 6 : 
                 Stream.junk(strm__);
@@ -704,20 +704,20 @@ function make_lexer(keywords) {
         if (c1 >= 48) {
           Stream.junk(strm__);
           var match$1 = Stream.peek(strm__);
-          /* initialize */var exit$1 = 0;
+          var exit$1 = 0;
           if (match$1) {
             var c2 = match$1[1];
             if (9 < (-48 + c2 >>> 0)) {
-              exit$1 = 52;
+              exit$1 = 2;
             }
             else {
               Stream.junk(strm__);
               var match$2 = Stream.peek(strm__);
-              /* initialize */var exit$2 = 0;
+              var exit$2 = 0;
               if (match$2) {
                 var c3 = match$2[1];
                 if (9 < (-48 + c3 >>> 0)) {
-                  exit$2 = 50;
+                  exit$2 = 3;
                 }
                 else {
                   Stream.junk(strm__);
@@ -725,9 +725,9 @@ function make_lexer(keywords) {
                 }
               }
               else {
-                exit$2 = 50;
+                exit$2 = 3;
               }
-              if (exit$2 === 50) {
+              if (exit$2 === 3) {
                 throw [
                       0,
                       Stream.$$Error,
@@ -738,9 +738,9 @@ function make_lexer(keywords) {
             }
           }
           else {
-            exit$1 = 52;
+            exit$1 = 2;
           }
-          if (exit$1 === 52) {
+          if (exit$1 === 2) {
             throw [
                   0,
                   Stream.$$Error,
@@ -750,10 +750,10 @@ function make_lexer(keywords) {
           
         }
         else {
-          exit = 56;
+          exit = 1;
         }
       }
-      if (exit === 56) {
+      if (exit === 1) {
         Stream.junk(strm__);
         return c1;
       }
@@ -779,10 +779,10 @@ function make_lexer(keywords) {
     while(/* true */1) {
       var match = Stream.peek(strm__);
       if (match) {
-        /* initialize */var exit = 0;
+        var exit = 0;
         var switcher = -40 + match[1];
         if (2 < (switcher >>> 0)) {
-          exit = 60;
+          exit = 1;
         }
         else {
           switch (switcher) {
@@ -790,7 +790,7 @@ function make_lexer(keywords) {
                 Stream.junk(strm__);
                 return maybe_nested_comment(strm__);
             case 1 : 
-                exit = 60;
+                exit = 1;
                 break;
             case 2 : 
                 Stream.junk(strm__);
@@ -798,7 +798,7 @@ function make_lexer(keywords) {
             
           }
         }
-        if (exit === 60) {
+        if (exit === 1) {
           Stream.junk(strm__);
         }
         

--- a/jscomp/stdlib/list.js
+++ b/jscomp/stdlib/list.js
@@ -641,10 +641,10 @@ function stable_sort(cmp, l) {
     };
   };
   var sort = function (n, l) {
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (n !== 2) {
       if (n !== 3) {
-        exit = 41;
+        exit = 1;
       }
       else {
         if (l) {
@@ -738,15 +738,15 @@ function stable_sort(cmp, l) {
                       );
             }
             else {
-              exit = 41;
+              exit = 1;
             }
           }
           else {
-            exit = 41;
+            exit = 1;
           }
         }
         else {
-          exit = 41;
+          exit = 1;
         }
       }
     }
@@ -775,14 +775,14 @@ function stable_sort(cmp, l) {
                   ];
         }
         else {
-          exit = 41;
+          exit = 1;
         }
       }
       else {
-        exit = 41;
+        exit = 1;
       }
     }
-    if (exit === 41) {
+    if (exit === 1) {
       var n1 = (n >> 1);
       var n2 = n - n1;
       var l2 = chop(n1, l);
@@ -793,10 +793,10 @@ function stable_sort(cmp, l) {
     
   };
   var rev_sort = function (n, l) {
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (n !== 2) {
       if (n !== 3) {
-        exit = 47;
+        exit = 1;
       }
       else {
         if (l) {
@@ -890,15 +890,15 @@ function stable_sort(cmp, l) {
                       );
             }
             else {
-              exit = 47;
+              exit = 1;
             }
           }
           else {
-            exit = 47;
+            exit = 1;
           }
         }
         else {
-          exit = 47;
+          exit = 1;
         }
       }
     }
@@ -927,14 +927,14 @@ function stable_sort(cmp, l) {
                   ];
         }
         else {
-          exit = 47;
+          exit = 1;
         }
       }
       else {
-        exit = 47;
+        exit = 1;
       }
     }
-    if (exit === 47) {
+    if (exit === 1) {
       var n1 = (n >> 1);
       var n2 = n - n1;
       var l2 = chop(n1, l);
@@ -1048,10 +1048,10 @@ function sort_uniq(cmp, l) {
     };
   };
   var sort = function (n, l) {
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (n !== 2) {
       if (n !== 3) {
-        exit = 14;
+        exit = 1;
       }
       else {
         if (l) {
@@ -1231,15 +1231,15 @@ function sort_uniq(cmp, l) {
               }
             }
             else {
-              exit = 14;
+              exit = 1;
             }
           }
           else {
-            exit = 14;
+            exit = 1;
           }
         }
         else {
-          exit = 14;
+          exit = 1;
         }
       }
     }
@@ -1275,14 +1275,14 @@ function sort_uniq(cmp, l) {
                   ];
         }
         else {
-          exit = 14;
+          exit = 1;
         }
       }
       else {
-        exit = 14;
+        exit = 1;
       }
     }
-    if (exit === 14) {
+    if (exit === 1) {
       var n1 = (n >> 1);
       var n2 = n - n1;
       var l2 = chop(n1, l);
@@ -1293,10 +1293,10 @@ function sort_uniq(cmp, l) {
     
   };
   var rev_sort = function (n, l) {
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (n !== 2) {
       if (n !== 3) {
-        exit = 27;
+        exit = 1;
       }
       else {
         if (l) {
@@ -1476,15 +1476,15 @@ function sort_uniq(cmp, l) {
               }
             }
             else {
-              exit = 27;
+              exit = 1;
             }
           }
           else {
-            exit = 27;
+            exit = 1;
           }
         }
         else {
-          exit = 27;
+          exit = 1;
         }
       }
     }
@@ -1520,14 +1520,14 @@ function sort_uniq(cmp, l) {
                   ];
         }
         else {
-          exit = 27;
+          exit = 1;
         }
       }
       else {
-        exit = 27;
+        exit = 1;
       }
     }
-    if (exit === 27) {
+    if (exit === 1) {
       var n1 = (n >> 1);
       var n2 = n - n1;
       var l2 = chop(n1, l);

--- a/jscomp/stdlib/map.js
+++ b/jscomp/stdlib/map.js
@@ -369,7 +369,7 @@ function Make(funarg) {
     }
   };
   var merge$1 = function (f, s1, s2) {
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (s1) {
       var v1 = s1[2];
       if (s1[5] >= height(s2)) {
@@ -380,18 +380,18 @@ function Make(funarg) {
                       ], match[2]), merge$1(f, s1[4], match[3]));
       }
       else {
-        exit = 20;
+        exit = 1;
       }
     }
     else {
       if (s2) {
-        exit = 20;
+        exit = 1;
       }
       else {
         return /* Empty */0;
       }
     }
-    if (exit === 20) {
+    if (exit === 1) {
       if (s2) {
         var v2 = s2[2];
         var match$1 = split(v2, s1);

--- a/jscomp/stdlib/scanf.js
+++ b/jscomp/stdlib/scanf.js
@@ -457,10 +457,10 @@ function token_bool(ib) {
 
 function token_int_literal(conv, ib) {
   var tok;
-  /* initialize */var exit = 0;
+  var exit = 0;
   var switcher = -88 + conv;
   if (32 < (switcher >>> 0)) {
-    exit = 228;
+    exit = 1;
   }
   else {
     switch (switcher) {
@@ -473,7 +473,7 @@ function token_int_literal(conv, ib) {
       case 12 : 
       case 17 : 
       case 29 : 
-          exit = 226;
+          exit = 2;
           break;
       case 1 : 
       case 2 : 
@@ -501,17 +501,17 @@ function token_int_literal(conv, ib) {
       case 28 : 
       case 30 : 
       case 31 : 
-          exit = 228;
+          exit = 1;
           break;
       case 0 : 
       case 32 : 
-          exit = 227;
+          exit = 3;
           break;
       
     }
   }
   switch (exit) {
-    case 228 : 
+    case 1 : 
         throw [
               0,
               Caml_exceptions.Assert_failure,
@@ -522,10 +522,10 @@ function token_int_literal(conv, ib) {
                 11
               ]
             ];
-    case 226 : 
+    case 2 : 
         tok = token(ib);
         break;
-    case 227 : 
+    case 3 : 
         tok = "0x" + token(ib);
         break;
     
@@ -745,14 +745,14 @@ function scan_unsigned_int(width, ib) {
         return width$1;
       }
       else {
-        /* initialize */var exit = 0;
+        var exit = 0;
         if (c$1 >= 99) {
           if (c$1 !== 111) {
             if (c$1 !== 120) {
               return scan_decimal_digits(width$1, ib);
             }
             else {
-              exit = 178;
+              exit = 1;
             }
           }
           else {
@@ -764,10 +764,10 @@ function scan_unsigned_int(width, ib) {
             return c$1 >= 98 ? scan_binary_int(store_char(width$1, ib, c$1), ib) : scan_decimal_digits(width$1, ib);
           }
           else {
-            exit = 178;
+            exit = 1;
           }
         }
-        if (exit === 178) {
+        if (exit === 1) {
           return scan_hexadecimal_int(store_char(width$1, ib, c$1), ib);
         }
         
@@ -785,10 +785,10 @@ function scan_optionally_signed_int(width, ib) {
 }
 
 function scan_int_conv(conv, width, ib) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   var switcher = -88 + conv;
   if (32 < (switcher >>> 0)) {
-    exit = 174;
+    exit = 1;
   }
   else {
     switch (switcher) {
@@ -828,7 +828,7 @@ function scan_int_conv(conv, width, ib) {
       case 28 : 
       case 30 : 
       case 31 : 
-          exit = 174;
+          exit = 1;
           break;
       case 0 : 
       case 32 : 
@@ -836,7 +836,7 @@ function scan_int_conv(conv, width, ib) {
       
     }
   }
-  if (exit === 174) {
+  if (exit === 1) {
     throw [
           0,
           Caml_exceptions.Assert_failure,
@@ -870,19 +870,19 @@ function scan_exp_part(width, ib) {
       return width;
     }
     else {
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (c !== 69) {
         if (c !== 101) {
           return width;
         }
         else {
-          exit = 165;
+          exit = 1;
         }
       }
       else {
-        exit = 165;
+        exit = 1;
       }
-      if (exit === 165) {
+      if (exit === 1) {
         return scan_optionally_signed_decimal_int(store_char(width, ib, c), ib);
       }
       
@@ -987,25 +987,25 @@ function scan_string(stp, width, ib) {
             }
           }
           else {
-            /* initialize */var exit = 0;
+            var exit = 0;
             var switcher = -9 + c;
             if (!(4 < (switcher >>> 0))) {
               if (1 < (-2 + switcher >>> 0)) {
                 return width;
               }
               else {
-                exit = 145;
+                exit = 1;
               }
             }
             else {
               if (switcher !== 23) {
-                exit = 145;
+                exit = 1;
               }
               else {
                 return width;
               }
             }
-            if (exit === 145) {
+            if (exit === 1) {
               _width = store_char(width, ib, c);
             }
             
@@ -1122,12 +1122,12 @@ function check_next_char_for_string(param, param$1) {
 
 function scan_backslash_char(width, ib) {
   var c = check_next_char_for_char(width, ib);
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (c >= 40) {
     if (c >= 58) {
       var switcher = -92 + c;
       if (28 < (switcher >>> 0)) {
-        exit = 128;
+        exit = 1;
       }
       else {
         switch (switcher) {
@@ -1136,7 +1136,7 @@ function scan_backslash_char(width, ib) {
           case 18 : 
           case 22 : 
           case 24 : 
-              exit = 126;
+              exit = 2;
               break;
           case 1 : 
           case 2 : 
@@ -1161,7 +1161,7 @@ function scan_backslash_char(width, ib) {
           case 25 : 
           case 26 : 
           case 27 : 
-              exit = 128;
+              exit = 1;
               break;
           case 28 : 
               var get_digit = function () {
@@ -1191,19 +1191,19 @@ function scan_backslash_char(width, ib) {
         return store_char(width - 2, ib, char_for_decimal_code(c, c1$1, c2$1));
       }
       else {
-        exit = 128;
+        exit = 1;
       }
     }
   }
   else {
     exit = c !== 34 ? (
-        c >= 39 ? 126 : 128
-      ) : 126;
+        c >= 39 ? 2 : 1
+      ) : 2;
   }
   switch (exit) {
-    case 128 : 
+    case 1 : 
         return bad_input_escape(c);
-    case 126 : 
+    case 2 : 
         return store_char(width, ib, char_for_backslash(c));
     
   }
@@ -1326,22 +1326,22 @@ function scan_chars_in_char_set(char_set, scan_indic, width, ib) {
 }
 
 function scanf_bad_input(ib, x) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   var s;
   if (x[1] === Scan_failure) {
     s = x[2];
-    exit = 91;
+    exit = 1;
   }
   else {
     if (x[1] === Caml_exceptions.Failure) {
       s = x[2];
-      exit = 91;
+      exit = 1;
     }
     else {
       throw x;
     }
   }
-  if (exit === 91) {
+  if (exit === 1) {
     var i = char_count(ib);
     return bad_input(Printf.sprintf([
                       /* Format */0,
@@ -1602,9 +1602,9 @@ function make_scanf(ib, _fmt, readers) {
         case 2 : 
             var rest = fmt[2];
             var pad = fmt[1];
-            /* initialize */var exit = 0;
+            var exit = 0;
             if (typeof rest === "number") {
-              exit = 67;
+              exit = 1;
             }
             else {
               switch (rest[0]) {
@@ -1649,10 +1649,10 @@ function make_scanf(ib, _fmt, readers) {
                     }
                     break;
                 default:
-                  exit = 67;
+                  exit = 1;
               }
             }
-            if (exit === 67) {
+            if (exit === 1) {
               var scan$3 = function (width, _, ib) {
                 return scan_string(/* None */0, width, ib);
               };
@@ -1824,9 +1824,9 @@ function make_scanf(ib, _fmt, readers) {
             var rest$1 = fmt[3];
             var char_set = fmt[2];
             var width_opt = fmt[1];
-            /* initialize */var exit$1 = 0;
+            var exit$1 = 0;
             if (typeof rest$1 === "number") {
-              exit$1 = 69;
+              exit$1 = 1;
             }
             else {
               if (rest$1[0] === 17) {
@@ -1851,10 +1851,10 @@ function make_scanf(ib, _fmt, readers) {
                       ];
               }
               else {
-                exit$1 = 69;
+                exit$1 = 1;
               }
             }
-            if (exit$1 === 69) {
+            if (exit$1 === 1) {
               var width$1 = width_of_pad_opt(width_opt);
               scan_chars_in_char_set(char_set, /* None */0, width$1, ib);
               var s$3 = token(ib);
@@ -1996,17 +1996,17 @@ function kscanf(ib, ef, param) {
       ];
     }
     catch (exc){
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (exc[1] === Scan_failure) {
-        exit = 21;
+        exit = 1;
       }
       else {
         if (exc[1] === Caml_exceptions.Failure) {
-          exit = 21;
+          exit = 1;
         }
         else {
           if (exc === Caml_exceptions.End_of_file) {
-            exit = 21;
+            exit = 1;
           }
           else {
             if (exc[1] === Caml_exceptions.Invalid_argument) {
@@ -2018,7 +2018,7 @@ function kscanf(ib, ef, param) {
           }
         }
       }
-      if (exit === 21) {
+      if (exit === 1) {
         match = [
           /* Exc */1,
           exc

--- a/jscomp/stdlib/set.js
+++ b/jscomp/stdlib/set.js
@@ -502,9 +502,9 @@ function Make(funarg) {
   };
   var of_sorted_list = function (l) {
     var sub = function (n, l) {
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (3 < (n >>> 0)) {
-        exit = 6;
+        exit = 1;
       }
       else {
         switch (n) {
@@ -529,7 +529,7 @@ function Make(funarg) {
                       ];
               }
               else {
-                exit = 6;
+                exit = 1;
               }
               break;
           case 2 : 
@@ -555,11 +555,11 @@ function Make(funarg) {
                         ];
                 }
                 else {
-                  exit = 6;
+                  exit = 1;
                 }
               }
               else {
-                exit = 6;
+                exit = 1;
               }
               break;
           case 3 : 
@@ -593,21 +593,21 @@ function Make(funarg) {
                           ];
                   }
                   else {
-                    exit = 6;
+                    exit = 1;
                   }
                 }
                 else {
-                  exit = 6;
+                  exit = 1;
                 }
               }
               else {
-                exit = 6;
+                exit = 1;
               }
               break;
           
         }
       }
-      if (exit === 6) {
+      if (exit === 1) {
         var nl = n / 2 | 0;
         var match$3 = sub(nl, l);
         var l$1 = match$3[2];

--- a/jscomp/stdlib/stream.js
+++ b/jscomp/stdlib/stream.js
@@ -233,9 +233,9 @@ function peek(s) {
 function junk(s) {
   while(/* true */1) {
     var match = s[2];
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (typeof match === "number") {
-      exit = 24;
+      exit = 1;
     }
     else {
       switch (match[0]) {
@@ -251,7 +251,7 @@ function junk(s) {
               return /* () */0;
             }
             else {
-              exit = 24;
+              exit = 1;
             }
             break;
         case 4 : 
@@ -260,10 +260,10 @@ function junk(s) {
             ++ b[4];
             return /* () */0;
         default:
-          exit = 24;
+          exit = 1;
       }
     }
-    if (exit === 24) {
+    if (exit === 1) {
       var match$2 = peek(s);
       if (!match$2) {
         return /* () */0;

--- a/jscomp/stdlib/string.js
+++ b/jscomp/stdlib/string.js
@@ -100,11 +100,11 @@ function escaped(s) {
       }
       else {
         var c = s.charCodeAt(i);
-        /* initialize */var exit = 0;
+        var exit = 0;
         if (c >= 14) {
           if (c !== 34) {
             if (c !== 92) {
-              exit = 15;
+              exit = 1;
             }
             else {
               return /* true */1;
@@ -120,7 +120,7 @@ function escaped(s) {
               return /* true */1;
             }
             else {
-              exit = 15;
+              exit = 1;
             }
           }
           else {
@@ -128,11 +128,11 @@ function escaped(s) {
               return /* true */1;
             }
             else {
-              exit = 15;
+              exit = 1;
             }
           }
         }
-        if (exit === 15) {
+        if (exit === 1) {
           if (Caml_string.caml_is_printable(c)) {
             _i = i + 1;
           }

--- a/jscomp/stdlib/weak.js
+++ b/jscomp/stdlib/weak.js
@@ -399,7 +399,7 @@ function Make(H) {
         else {
           if (h === hashes[i]) {
             var match = Caml_primitive.caml_weak_get_copy(bucket, i);
-            /* initialize */var exit = 0;
+            var exit = 0;
             if (match) {
               if (H[1](match[1], d)) {
                 var match$1 = Caml_primitive.caml_weak_get(bucket, i);
@@ -416,13 +416,13 @@ function Make(H) {
                 }
               }
               else {
-                exit = 5;
+                exit = 1;
               }
             }
             else {
-              exit = 5;
+              exit = 1;
             }
-            if (exit === 5) {
+            if (exit === 1) {
               _i = i + 1;
             }
             

--- a/jscomp/test/ext_bytes.js
+++ b/jscomp/test/ext_bytes.js
@@ -33,10 +33,10 @@ function escaped(s) {
     n = 0;
     for(var i$1 = 0 ,i_finish$1 = s.length - 1; i$1<= i_finish$1; ++i$1){
       var c = s[i$1];
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (c >= 35) {
         c !== 92 ? (
-            c >= 127 ? (exit = 4) : (s$prime[n] = c)
+            c >= 127 ? (exit = 1) : (s$prime[n] = c)
           ) : (exit = 2);
       }
       else {
@@ -45,7 +45,7 @@ function escaped(s) {
         }
         else {
           if (c >= 14) {
-            exit = 4;
+            exit = 1;
           }
           else {
             switch (c) {
@@ -74,7 +74,7 @@ function escaped(s) {
               case 7 : 
               case 11 : 
               case 12 : 
-                  exit = 4;
+                  exit = 1;
                   break;
               case 13 : 
                   s$prime[n] = /* "\\" */92;
@@ -87,7 +87,7 @@ function escaped(s) {
         }
       }
       switch (exit) {
-        case 4 : 
+        case 1 : 
             s$prime[n] = /* "\\" */92;
             ++ n;
             s$prime[n] = 48 + (c / 100 | 0);

--- a/jscomp/test/ext_filename.js
+++ b/jscomp/test/ext_filename.js
@@ -67,7 +67,7 @@ function relative_path(file1, file2) {
     while(/* true */1) {
       var dir2 = _dir2;
       var dir1 = _dir1;
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (dir1) {
         if (dir2) {
           if (dir1[1] === dir2[1]) {
@@ -75,17 +75,17 @@ function relative_path(file1, file2) {
             _dir1 = dir1[2];
           }
           else {
-            exit = 3;
+            exit = 1;
           }
         }
         else {
-          exit = 3;
+          exit = 1;
         }
       }
       else {
-        exit = 3;
+        exit = 1;
       }
-      if (exit === 3) {
+      if (exit === 1) {
         return Pervasives.$at(List.map(function () {
                         return node_parent;
                       }, dir2), dir1);
@@ -94,19 +94,19 @@ function relative_path(file1, file2) {
     };
   };
   var ys = go(dir1, dir2);
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (ys) {
     if (ys[1] === node_parent) {
       return $$String.concat(node_sep, ys);
     }
     else {
-      exit = 2;
+      exit = 1;
     }
   }
   else {
-    exit = 2;
+    exit = 1;
   }
-  if (exit === 2) {
+  if (exit === 1) {
     return $$String.concat(node_sep, [
                 /* :: */0,
                 node_current,

--- a/jscomp/test/ext_list.js
+++ b/jscomp/test/ext_list.js
@@ -201,18 +201,18 @@ function flat_map(f, lx) {
 }
 
 function map2_last(f, l1, l2) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (l1) {
     var l1$1 = l1[2];
     var u = l1[1];
-    /* initialize */var exit$1 = 0;
+    var exit$1 = 0;
     if (l1$1) {
-      exit$1 = 16;
+      exit$1 = 2;
     }
     else {
       if (l2) {
         if (l2[2]) {
-          exit$1 = 16;
+          exit$1 = 2;
         }
         else {
           return [
@@ -223,10 +223,10 @@ function map2_last(f, l1, l2) {
         }
       }
       else {
-        exit = 15;
+        exit = 1;
       }
     }
-    if (exit$1 === 16) {
+    if (exit$1 === 2) {
       if (l2) {
         var r = f(/* false */0, u, l2[1]);
         return [
@@ -236,20 +236,20 @@ function map2_last(f, l1, l2) {
               ];
       }
       else {
-        exit = 15;
+        exit = 1;
       }
     }
     
   }
   else {
     if (l2) {
-      exit = 15;
+      exit = 1;
     }
     else {
       return /* [] */0;
     }
   }
-  if (exit === 15) {
+  if (exit === 1) {
     return Pervasives.invalid_arg("List.map2_last");
   }
   

--- a/jscomp/test/int_map.js
+++ b/jscomp/test/int_map.js
@@ -398,7 +398,7 @@ function split(x, param) {
 }
 
 function merge$1(f, s1, s2) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (s1) {
     var v1 = s1[2];
     if (s1[5] >= height(s2)) {
@@ -409,18 +409,18 @@ function merge$1(f, s1, s2) {
                     ], match[2]), merge$1(f, s1[4], match[3]));
     }
     else {
-      exit = 20;
+      exit = 1;
     }
   }
   else {
     if (s2) {
-      exit = 20;
+      exit = 1;
     }
     else {
       return /* Empty */0;
     }
   }
-  if (exit === 20) {
+  if (exit === 1) {
     if (s2) {
       var v2 = s2[2];
       var match$1 = split(v2, s1);

--- a/jscomp/test/qcc.js
+++ b/jscomp/test/qcc.js
@@ -248,7 +248,7 @@ function cconst() {
 function skip(_param) {
   while(/* true */1) {
     var ch = getch(/* () */0);
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (ch >= 14) {
       if (ch !== 32) {
         return ch !== 47 ? ch : (
@@ -256,13 +256,13 @@ function skip(_param) {
                 );
       }
       else {
-        exit = 116;
+        exit = 1;
       }
     }
     else {
       if (ch >= 11) {
         if (ch >= 13) {
-          exit = 116;
+          exit = 1;
         }
         else {
           return ch;
@@ -270,14 +270,14 @@ function skip(_param) {
       }
       else {
         if (ch >= 9) {
-          exit = 116;
+          exit = 1;
         }
         else {
           return ch;
         }
       }
     }
-    if (exit === 116) {
+    if (exit === 1) {
       _param = /* () */0;
     }
     
@@ -319,11 +319,11 @@ function next() {
   }
   if (match) {
     var c = match[1];
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (c !== 34) {
       if (c >= 48) {
         if (c >= 58) {
-          exit = 115;
+          exit = 1;
         }
         else {
           return ilit(c - 48);
@@ -331,7 +331,7 @@ function next() {
       }
       else {
         if (c !== 39) {
-          exit = 115;
+          exit = 1;
         }
         else {
           return cconst(/* () */0);
@@ -341,7 +341,7 @@ function next() {
     else {
       return slit(gpos[1], gpos[1]);
     }
-    if (exit === 115) {
+    if (exit === 1) {
       return isid(c) ? id(0, c) : op(c, [
                     /* :: */0,
                     "++",
@@ -1244,7 +1244,7 @@ function postfix(stk) {
   }
   else {
     var op = t[1];
-    /* initialize */var exit = 0;
+    var exit = 0;
     switch (op) {
       case "(" : 
           var emitargs = function (_l, _rl) {
@@ -1311,12 +1311,12 @@ function postfix(stk) {
           return align[1] % 2 !== 0 ? out(1216594952) : 0;
       case "++" : 
       case "--" : 
-          exit = 77;
+          exit = 1;
           break;
       default:
         return unnext(t);
     }
-    if (exit === 77) {
+    if (exit === 1) {
       patchlval(/* () */0);
       out(4753857);
       read(lval[1][2]);
@@ -1556,7 +1556,7 @@ function stmt(brk, stk) {
     return next$1(/* () */0);
   };
   var t = next$1(/* () */0);
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (Caml_primitive.caml_equal(t, tokif)) {
     pexpr(stk);
     var loc = test(0, 0);
@@ -1684,7 +1684,7 @@ function stmt(brk, stk) {
         }
         else {
           if (t[0]) {
-            exit = 50;
+            exit = 1;
           }
           else {
             switch (t[1]) {
@@ -1693,14 +1693,14 @@ function stmt(brk, stk) {
               case "{" : 
                   return block(brk, stk);
               default:
-                exit = 50;
+                exit = 1;
             }
           }
         }
       }
     }
   }
-  if (exit === 50) {
+  if (exit === 1) {
     unnext(t);
     expr(stk);
     return next$1(/* () */0);
@@ -1751,19 +1751,19 @@ function top(_param) {
               var n = _n;
               var regs = _regs;
               var match = next$1(/* () */0);
-              /* initialize */var exit = 0;
+              var exit = 0;
               switch (match[0]) {
                 case 0 : 
                     if (match[1] === ")") {
                       return stk;
                     }
                     else {
-                      exit = 33;
+                      exit = 1;
                     }
                     break;
                 case 1 : 
                 case 2 : 
-                    exit = 33;
+                    exit = 1;
                     break;
                 case 3 : 
                     var r = List.hd(regs);
@@ -1790,7 +1790,7 @@ function top(_param) {
                     break;
                 
               }
-              if (exit === 33) {
+              if (exit === 1) {
                 return Pervasives.failwith("[var] or ) expected");
               }
               

--- a/jscomp/test/rec_value_test.js
+++ b/jscomp/test/rec_value_test.js
@@ -283,7 +283,7 @@ var suites_002 = [
     "mutual",
     function () {
       var $js;
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (a) {
         if (b) {
           var match = b[2];

--- a/jscomp/test/test_bug.js
+++ b/jscomp/test/test_bug.js
@@ -8,19 +8,19 @@ function escaped(s) {
   for(var i = 0 ,i_finish = s.length - 1; i<= i_finish; ++i){
     var c = s[i];
     var $js;
-    /* initialize */var exit = 0;
+    var exit = 0;
     c >= 14 ? (
         c !== 34 ? (
-            c !== 92 ? (exit = 6) : ($js = 2)
+            c !== 92 ? (exit = 1) : ($js = 2)
           ) : ($js = 2)
       ) : (
         c >= 11 ? (
-            c >= 13 ? ($js = 2) : (exit = 6)
+            c >= 13 ? ($js = 2) : (exit = 1)
           ) : (
-            c >= 8 ? ($js = 2) : (exit = 6)
+            c >= 8 ? ($js = 2) : (exit = 1)
           )
       );
-    if (exit === 6) {
+    if (exit === 1) {
       $js = Caml_string.caml_is_printable(c) ? 1 : 4;
     }
     n += $js;
@@ -33,7 +33,7 @@ function escaped(s) {
     n = 0;
     for(var i$1 = 0 ,i_finish$1 = s.length - 1; i$1<= i_finish$1; ++i$1){
       var c$1 = s[i$1];
-      /* initialize */var exit$1 = 0;
+      var exit$1 = 0;
       var switcher = -34 + c$1;
       if (!(58 < (switcher >>> 0))) {
         if (56 < (-1 + switcher >>> 0)) {
@@ -42,12 +42,12 @@ function escaped(s) {
           s$prime[n] = c$1;
         }
         else {
-          exit$1 = 3;
+          exit$1 = 1;
         }
       }
       else {
         if (switcher >= -20) {
-          exit$1 = 3;
+          exit$1 = 1;
         }
         else {
           switch (34 + switcher) {
@@ -76,7 +76,7 @@ function escaped(s) {
             case 7 : 
             case 11 : 
             case 12 : 
-                exit$1 = 3;
+                exit$1 = 1;
                 break;
             case 13 : 
                 s$prime[n] = /* "\\" */92;
@@ -87,7 +87,7 @@ function escaped(s) {
           }
         }
       }
-      if (exit$1 === 3) {
+      if (exit$1 === 1) {
         if (Caml_string.caml_is_printable(c$1)) {
           s$prime[n] = c$1;
         }

--- a/jscomp/test/test_char.js
+++ b/jscomp/test/test_char.js
@@ -12,11 +12,11 @@ function chr(n) {
 }
 
 function escaped(c) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (c !== 39) {
     if (c !== 92) {
       if (c >= 14) {
-        exit = 7;
+        exit = 1;
       }
       else {
         switch (c) {
@@ -36,7 +36,7 @@ function escaped(c) {
           case 7 : 
           case 11 : 
           case 12 : 
-              exit = 7;
+              exit = 1;
               break;
           case 13 : 
               return "\\r";
@@ -51,7 +51,7 @@ function escaped(c) {
   else {
     return "\\'";
   }
-  if (exit === 7) {
+  if (exit === 1) {
     if (Caml_string.caml_is_printable(c)) {
       var s = new Array(1);
       /* unknown */"string.unsafe_set";

--- a/jscomp/test/test_fastdt.js
+++ b/jscomp/test/test_fastdt.js
@@ -315,7 +315,7 @@ function trim_tree_same(dt) {
       var n = l[1];
       var t = trim_tree_same$prime(n[2]);
       var f = trim_tree_same$prime(n[3]);
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (t[0]) {
         var p1 = t[1];
         if (f[0]) {
@@ -336,13 +336,13 @@ function trim_tree_same(dt) {
                   ];
         }
         else {
-          exit = 102;
+          exit = 1;
         }
       }
       else {
-        exit = 102;
+        exit = 1;
       }
-      if (exit === 102) {
+      if (exit === 1) {
         return [
                 /* Node */0,
                 [
@@ -970,7 +970,7 @@ function print_tree(out, dt) {
 function read_tree(h) {
   var l = Pervasives.input_line(h);
   var match = split_white(l);
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (match) {
     switch (match[1]) {
       case "L" : 
@@ -979,7 +979,7 @@ function read_tree(h) {
             var match$2 = match$1[2];
             if (match$2) {
               if (match$2[2]) {
-                exit = 28;
+                exit = 1;
               }
               else {
                 return [
@@ -989,18 +989,18 @@ function read_tree(h) {
               }
             }
             else {
-              exit = 28;
+              exit = 1;
             }
           }
           else {
-            exit = 28;
+            exit = 1;
           }
           break;
       case "N" : 
           var match$3 = match[2];
           if (match$3) {
             if (match$3[2]) {
-              exit = 28;
+              exit = 1;
             }
             else {
               var s = get_fid(match$3[1]);
@@ -1018,17 +1018,17 @@ function read_tree(h) {
             }
           }
           else {
-            exit = 28;
+            exit = 1;
           }
           break;
       default:
-        exit = 28;
+        exit = 1;
     }
   }
   else {
-    exit = 28;
+    exit = 1;
   }
-  if (exit === 28) {
+  if (exit === 1) {
     return Pervasives.failwith("malformed line: '" + (l + "'"));
   }
   

--- a/jscomp/test/test_for_map.js
+++ b/jscomp/test/test_for_map.js
@@ -398,7 +398,7 @@ function split(x, param) {
 }
 
 function merge$1(f, s1, s2) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (s1) {
     var v1 = s1[2];
     if (s1[5] >= height(s2)) {
@@ -409,18 +409,18 @@ function merge$1(f, s1, s2) {
                     ], match[2]), merge$1(f, s1[4], match[3]));
     }
     else {
-      exit = 20;
+      exit = 1;
     }
   }
   else {
     if (s2) {
-      exit = 20;
+      exit = 1;
     }
     else {
       return /* Empty */0;
     }
   }
-  if (exit === 20) {
+  if (exit === 1) {
     if (s2) {
       var v2 = s2[2];
       var match$1 = split(v2, s1);

--- a/jscomp/test/test_internalOO.js
+++ b/jscomp/test/test_internalOO.js
@@ -434,7 +434,7 @@ function split(x, param) {
 }
 
 function merge$1(f, s1, s2) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (s1) {
     var v1 = s1[2];
     if (s1[5] >= height(s2)) {
@@ -445,18 +445,18 @@ function merge$1(f, s1, s2) {
                     ], match[2]), merge$1(f, s1[4], match[3]));
     }
     else {
-      exit = 20;
+      exit = 1;
     }
   }
   else {
     if (s2) {
-      exit = 20;
+      exit = 1;
     }
     else {
       return /* Empty */0;
     }
   }
-  if (exit === 20) {
+  if (exit === 1) {
     if (s2) {
       var v2 = s2[2];
       var match$1 = split(v2, s1);
@@ -1042,7 +1042,7 @@ function split$1(x, param) {
 }
 
 function merge$3(f, s1, s2) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (s1) {
     var v1 = s1[2];
     if (s1[5] >= height$1(s2)) {
@@ -1053,18 +1053,18 @@ function merge$3(f, s1, s2) {
                     ], match[2]), merge$3(f, s1[4], match[3]));
     }
     else {
-      exit = 20;
+      exit = 1;
     }
   }
   else {
     if (s2) {
-      exit = 20;
+      exit = 1;
     }
     else {
       return /* Empty */0;
     }
   }
-  if (exit === 20) {
+  if (exit === 1) {
     if (s2) {
       var v2 = s2[2];
       var match$1 = split$1(v2, s1);
@@ -1650,7 +1650,7 @@ function split$2(x, param) {
 }
 
 function merge$5(f, s1, s2) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (s1) {
     var v1 = s1[2];
     if (s1[5] >= height$2(s2)) {
@@ -1661,18 +1661,18 @@ function merge$5(f, s1, s2) {
                     ], match[2]), merge$5(f, s1[4], match[3]));
     }
     else {
-      exit = 20;
+      exit = 1;
     }
   }
   else {
     if (s2) {
-      exit = 20;
+      exit = 1;
     }
     else {
       return /* Empty */0;
     }
   }
-  if (exit === 20) {
+  if (exit === 1) {
     if (s2) {
       var v2 = s2[2];
       var match$1 = split$2(v2, s1);

--- a/jscomp/test/test_list.js
+++ b/jscomp/test/test_list.js
@@ -642,10 +642,10 @@ function stable_sort(cmp, l) {
     };
   };
   var sort = function (n, l) {
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (n !== 2) {
       if (n !== 3) {
-        exit = 41;
+        exit = 1;
       }
       else {
         if (l) {
@@ -739,15 +739,15 @@ function stable_sort(cmp, l) {
                       );
             }
             else {
-              exit = 41;
+              exit = 1;
             }
           }
           else {
-            exit = 41;
+            exit = 1;
           }
         }
         else {
-          exit = 41;
+          exit = 1;
         }
       }
     }
@@ -776,14 +776,14 @@ function stable_sort(cmp, l) {
                   ];
         }
         else {
-          exit = 41;
+          exit = 1;
         }
       }
       else {
-        exit = 41;
+        exit = 1;
       }
     }
-    if (exit === 41) {
+    if (exit === 1) {
       var n1 = (n >> 1);
       var n2 = n - n1;
       var l2 = chop(n1, l);
@@ -794,10 +794,10 @@ function stable_sort(cmp, l) {
     
   };
   var rev_sort = function (n, l) {
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (n !== 2) {
       if (n !== 3) {
-        exit = 47;
+        exit = 1;
       }
       else {
         if (l) {
@@ -891,15 +891,15 @@ function stable_sort(cmp, l) {
                       );
             }
             else {
-              exit = 47;
+              exit = 1;
             }
           }
           else {
-            exit = 47;
+            exit = 1;
           }
         }
         else {
-          exit = 47;
+          exit = 1;
         }
       }
     }
@@ -928,14 +928,14 @@ function stable_sort(cmp, l) {
                   ];
         }
         else {
-          exit = 47;
+          exit = 1;
         }
       }
       else {
-        exit = 47;
+        exit = 1;
       }
     }
-    if (exit === 47) {
+    if (exit === 1) {
       var n1 = (n >> 1);
       var n2 = n - n1;
       var l2 = chop(n1, l);
@@ -1049,10 +1049,10 @@ function sort_uniq(cmp, l) {
     };
   };
   var sort = function (n, l) {
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (n !== 2) {
       if (n !== 3) {
-        exit = 14;
+        exit = 1;
       }
       else {
         if (l) {
@@ -1232,15 +1232,15 @@ function sort_uniq(cmp, l) {
               }
             }
             else {
-              exit = 14;
+              exit = 1;
             }
           }
           else {
-            exit = 14;
+            exit = 1;
           }
         }
         else {
-          exit = 14;
+          exit = 1;
         }
       }
     }
@@ -1276,14 +1276,14 @@ function sort_uniq(cmp, l) {
                   ];
         }
         else {
-          exit = 14;
+          exit = 1;
         }
       }
       else {
-        exit = 14;
+        exit = 1;
       }
     }
-    if (exit === 14) {
+    if (exit === 1) {
       var n1 = (n >> 1);
       var n2 = n - n1;
       var l2 = chop(n1, l);
@@ -1294,10 +1294,10 @@ function sort_uniq(cmp, l) {
     
   };
   var rev_sort = function (n, l) {
-    /* initialize */var exit = 0;
+    var exit = 0;
     if (n !== 2) {
       if (n !== 3) {
-        exit = 27;
+        exit = 1;
       }
       else {
         if (l) {
@@ -1477,15 +1477,15 @@ function sort_uniq(cmp, l) {
               }
             }
             else {
-              exit = 27;
+              exit = 1;
             }
           }
           else {
-            exit = 27;
+            exit = 1;
           }
         }
         else {
-          exit = 27;
+          exit = 1;
         }
       }
     }
@@ -1521,14 +1521,14 @@ function sort_uniq(cmp, l) {
                   ];
         }
         else {
-          exit = 27;
+          exit = 1;
         }
       }
       else {
-        exit = 27;
+        exit = 1;
       }
     }
-    if (exit === 27) {
+    if (exit === 1) {
       var n1 = (n >> 1);
       var n2 = n - n1;
       var l2 = chop(n1, l);

--- a/jscomp/test/test_set.js
+++ b/jscomp/test/test_set.js
@@ -502,9 +502,9 @@ function Make(Ord) {
   };
   var of_sorted_list = function (l) {
     var sub = function (n, l) {
-      /* initialize */var exit = 0;
+      var exit = 0;
       if (3 < (n >>> 0)) {
-        exit = 7;
+        exit = 1;
       }
       else {
         switch (n) {
@@ -529,7 +529,7 @@ function Make(Ord) {
                       ];
               }
               else {
-                exit = 7;
+                exit = 1;
               }
               break;
           case 2 : 
@@ -555,11 +555,11 @@ function Make(Ord) {
                         ];
                 }
                 else {
-                  exit = 7;
+                  exit = 1;
                 }
               }
               else {
-                exit = 7;
+                exit = 1;
               }
               break;
           case 3 : 
@@ -593,21 +593,21 @@ function Make(Ord) {
                           ];
                   }
                   else {
-                    exit = 7;
+                    exit = 1;
                   }
                 }
                 else {
-                  exit = 7;
+                  exit = 1;
                 }
               }
               else {
-                exit = 7;
+                exit = 1;
               }
               break;
           
         }
       }
-      if (exit === 7) {
+      if (exit === 1) {
         var nl = n / 2 | 0;
         var match$3 = sub(nl, l);
         var l$1 = match$3[2];

--- a/jscomp/test/test_static_catch_ident.js
+++ b/jscomp/test/test_static_catch_ident.js
@@ -9,7 +9,7 @@ var Scan_failure = [
 ];
 
 function scanf_bad_input(_, x) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   var s;
   if (x[1] === Scan_failure) {
     s = x[2];

--- a/jscomp/test/ticker.js
+++ b/jscomp/test/ticker.js
@@ -14,11 +14,11 @@ function split(delim, s) {
       var i = _i;
       var l = _l;
       if (i !== 0) {
-        /* initialize */var exit = 0;
+        var exit = 0;
         var i$prime;
         try {
           i$prime = $$String.rindex_from(s, i - 1, delim);
-          exit = -1;
+          exit = 1;
         }
         catch (exn){
           if (exn === Caml_exceptions.Not_found) {
@@ -32,7 +32,7 @@ function split(delim, s) {
             throw exn;
           }
         }
-        if (exit === -1) {
+        if (exit === 1) {
           var l_001 = $$String.sub(s, i$prime + 1, i - i$prime - 1);
           var l$1 = [
             /* :: */0,
@@ -502,7 +502,7 @@ function split$1(x, param) {
 }
 
 function merge$1(f, s1, s2) {
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (s1) {
     var v1 = s1[2];
     if (s1[5] >= height(s2)) {
@@ -513,18 +513,18 @@ function merge$1(f, s1, s2) {
                     ], match[2]), merge$1(f, s1[4], match[3]));
     }
     else {
-      exit = 20;
+      exit = 1;
     }
   }
   else {
     if (s2) {
-      exit = 20;
+      exit = 1;
     }
     else {
       return /* Empty */0;
     }
   }
-  if (exit === 20) {
+  if (exit === 1) {
     if (s2) {
       var v2 = s2[2];
       var match$1 = split$1(v2, s1);
@@ -867,7 +867,7 @@ function process_input_line(ticker_map, all_tickers, line) {
           ];
   };
   var tokens = split(/* "|" */124, line);
-  /* initialize */var exit = 0;
+  var exit = 0;
   if (tokens) {
     switch (tokens[1]) {
       case "Q" : 
@@ -876,7 +876,7 @@ function process_input_line(ticker_map, all_tickers, line) {
             var match$1 = match[2];
             if (match$1) {
               if (match$1[2]) {
-                exit = 4;
+                exit = 1;
               }
               else {
                 var ticker_map$1 = ticker_map ? ticker_map[1] : compute_update_sequences(all_tickers);
@@ -893,11 +893,11 @@ function process_input_line(ticker_map, all_tickers, line) {
               }
             }
             else {
-              exit = 4;
+              exit = 1;
             }
           }
           else {
-            exit = 4;
+            exit = 1;
           }
           break;
       case "R" : 
@@ -913,7 +913,7 @@ function process_input_line(ticker_map, all_tickers, line) {
                       var match$5 = match$4[2];
                       if (match$5) {
                         if (match$5[2]) {
-                          exit = 4;
+                          exit = 1;
                         }
                         else {
                           return [
@@ -928,11 +928,11 @@ function process_input_line(ticker_map, all_tickers, line) {
                         }
                       }
                       else {
-                        exit = 4;
+                        exit = 1;
                       }
                     }
                     else {
-                      exit = 4;
+                      exit = 1;
                     }
                     break;
                 case "-" : 
@@ -941,7 +941,7 @@ function process_input_line(ticker_map, all_tickers, line) {
                       var match$7 = match$6[2];
                       if (match$7) {
                         if (match$7[2]) {
-                          exit = 4;
+                          exit = 1;
                         }
                         else {
                           return [
@@ -956,16 +956,16 @@ function process_input_line(ticker_map, all_tickers, line) {
                         }
                       }
                       else {
-                        exit = 4;
+                        exit = 1;
                       }
                     }
                     else {
-                      exit = 4;
+                      exit = 1;
                     }
                     break;
                 case "S" : 
                     if (match$3[2]) {
-                      exit = 4;
+                      exit = 1;
                     }
                     else {
                       return [
@@ -986,25 +986,25 @@ function process_input_line(ticker_map, all_tickers, line) {
                     }
                     break;
                 default:
-                  exit = 4;
+                  exit = 1;
               }
             }
             else {
-              exit = 4;
+              exit = 1;
             }
           }
           else {
-            exit = 4;
+            exit = 1;
           }
           break;
       default:
-        exit = 4;
+        exit = 1;
     }
   }
   else {
-    exit = 4;
+    exit = 1;
   }
-  if (exit === 4) {
+  if (exit === 1) {
     return Pervasives.failwith("Invalid input line");
   }
   


### PR DESCRIPTION
Adding an indirection layer between raw exit code and virtual exit code so that output is more stable and readable
invariants:
1. make sure initialization, handler, and raise are consistent
TODO:
optimization for simple cases, be careful when inlining (try with and single simple handler)