### PR TITLE
add empty obj unit test (+2 squashed commits)

### DIFF
--- a/jscomp/j.ml
+++ b/jscomp/j.ml
@@ -113,6 +113,9 @@ and expression_desc =
   | Seq of expression * expression
   | Cond of expression * expression * expression
   | Bin of binop * expression * expression
+
+  (* [int_op] will guarantee return [int32] bits 
+     https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators  *)
   (* | Int32_bin of int_op * expression * expression *)
   | FlatCall of expression * expression 
     (* f.apply(null,args) -- Fully applied guaranteed 

--- a/jscomp/j_helper.mli
+++ b/jscomp/j_helper.mli
@@ -63,6 +63,10 @@ val is_constant : J.expression -> bool
 
 val extract_non_pure : J.expression -> J.expression option
 
+type binary_op =   ?comment:string -> J.expression -> J.expression -> J.expression 
+
+type unary_op =  ?comment:string -> J.expression -> J.expression
+
 module Exp : sig 
   type t = J.expression 
 
@@ -139,15 +143,23 @@ module Exp : sig
 
   val is_type_number : ?comment:string -> t -> t
 
-  val bin : ?comment:string -> Js_op.binop -> t -> t -> t 
+  (* val bin : ?comment:string -> Js_op.binary_op -> t -> t -> t  *)
+  val to_int32 : unary_op
+  val to_uint32 : unary_op
 
-  val int_plus : ?comment:string -> t -> t -> t
+  val int_plus : binary_op
+  val int_minus : binary_op
+  val int32_lsl : binary_op
+  val int32_lsr : binary_op
+  val int32_asr : binary_op
+  val int32_mod : binary_op
+  val int32_bxor : binary_op
+  val int32_band : binary_op
+  val int32_bor : binary_op
+  val float_plus : binary_op
+  val float_minus : binary_op
+  val float_notequal : binary_op
 
-  val int_minus : ?comment:string -> t -> t -> t
-
-  val float_plus : ?comment:string -> t -> t -> t
-
-  val float_minus : ?comment:string -> t -> t -> t
   (* val un : ?comment:string -> Js_op.unop -> t -> t  *)
   val not : t -> t
 
@@ -219,14 +231,15 @@ module Exp : sig
 
   val stringcomp : ?comment:string -> Js_op.binop -> t -> t -> t
 
-  val add : ?comment:string -> t -> t -> t
 
-  val minus : ?comment:string -> t -> t -> t
-
-  val mul : ?comment:string -> t -> t -> t
-  
-  val div : ?comment:string -> t -> t -> t
-
+  val float_add : ?comment:string -> t -> t -> t
+  val float_minus : ?comment:string -> t -> t -> t
+  val float_mul : ?comment:string -> t -> t -> t
+  val float_div : ?comment:string -> t -> t -> t
+  val int32_div : ?comment:string -> t -> t -> t
+  val int32_add : ?comment:string -> t -> t -> t
+  val int32_minus : ?comment:string -> t -> t -> t
+  val int32_mul : ?comment:string -> t -> t -> t
   val of_block : ?comment:string -> J.statement list -> J.expression -> t
 end
 

--- a/jscomp/js_fold.ml
+++ b/jscomp/js_fold.ml
@@ -125,6 +125,8 @@ class virtual fold =
        val log3 : 'a -> 'b -> 'c -> unit 
      *)
                  (* TODO: Add some primitives so that [js inliner] can do a better job *)
+                 (* [int_op] will guarantee return [int32] bits 
+     https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators  *)
                  (* | Int32_bin of int_op * expression * expression *)
                  (* f.apply(null,args) -- Fully applied guaranteed 
        TODO: once we know args's shape --

--- a/jscomp/js_map.ml
+++ b/jscomp/js_map.ml
@@ -138,6 +138,8 @@ class virtual map =
        val log3 : 'a -> 'b -> 'c -> unit 
      *)
                  (* TODO: Add some primitives so that [js inliner] can do a better job *)
+                 (* [int_op] will guarantee return [int32] bits 
+     https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators  *)
                  (* | Int32_bin of int_op * expression * expression *)
                  (* f.apply(null,args) -- Fully applied guaranteed 
        TODO: once we know args's shape --

--- a/jscomp/js_op.ml
+++ b/jscomp/js_op.ml
@@ -52,6 +52,41 @@ type binop =
   | Div
   | Mod
 
+(**
+note that we don't need raise [Div_by_zero] in ocamlscript
+
+{[
+let add x y = x + y  (* | 0 *)
+let minus x y = x - y (* | 0 *)
+let mul x y = x * y   (* caml_mul | Math.imul *)
+let div x y = x / y (* caml_div (x/y|0)*)
+let imod x y = x mod y  (* caml_mod (x%y) (zero_divide)*)
+
+let bor x y = x lor y   (* x  | y *)
+let bxor x y = x lxor y (* x ^ y *)
+let band x y = x land y (* x & y *)
+let ilnot  y  = lnot y (* let lnot x = x lxor (-1) *)
+let ilsl x y = x lsl y (* x << y*)
+let ilsr x y = x lsr y  (* x >>> y | 0 *)
+let iasr  x y = x asr y (* x >> y *)
+]}
+
+
+Note that js treat unsigned shift 0 bits in a special way
+   Unsigned shifts convert their left-hand side to Uint32, 
+   signed shifts convert it to Int32.
+   Shifting by 0 digits returns the converted value.
+   {[
+    function ToUint32(x) {
+        return x >>> 0;
+    }
+    function ToInt32(x) {
+        return x >> 0;
+    }
+   ]}
+   So in Js, [-1 >>>0] will be the largest Uint32, while [-1>>0] will remain [-1]
+   and [-1 >>> 0 >> 0 ] will be [-1]
+*)
 type int_op = 
     
   | Bor
@@ -62,10 +97,17 @@ type int_op =
   | Asr
 
   | Plus
+      (* for [+], given two numbers 
+         x + y | 0
+       *)
   | Minus
+      (* x - y | 0 *)
   | Mul
+      (* *)
   | Div
+      (* x / y | 0 *)
   | Mod
+      (* x  % y *)
 
 (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Bitwise_operators
     {[

--- a/jscomp/js_op_util.ml
+++ b/jscomp/js_op_util.ml
@@ -51,18 +51,9 @@ let op_int_prec (op : Js_op.int_op) =
 
 let op_str (op : Js_op.binop) =
   match op with
-  | Eq      -> "="
-  | Or      -> "||"
-  | And     -> "&&"
   | Bor     -> "|"
   | Bxor    -> "^"
   | Band    -> "&"
-  | EqEqEq  -> "==="
-  | NotEqEq -> "!=="
-  | Lt      -> "<"
-  | Le      -> "<="
-  | Gt      -> ">"
-  | Ge      -> ">="
   | Lsl     -> "<<"
   | Lsr     -> ">>>"
   | Asr     -> ">>"
@@ -72,6 +63,31 @@ let op_str (op : Js_op.binop) =
   | Div     -> "/"
   | Mod     -> "%"
 
+  | Eq      -> "="
+  | Or      -> "||"
+  | And     -> "&&"
+  | EqEqEq  -> "==="
+  | NotEqEq -> "!=="
+  | Lt      -> "<"
+  | Le      -> "<="
+  | Gt      -> ">"
+  | Ge      -> ">="
+
+
+let op_int_str (op : Js_op.int_op) = 
+  match op with
+  | Bor     -> "|"
+  | Bxor    -> "^"
+  | Band    -> "&"
+  | Lsl     -> "<<"
+  | Lsr     -> ">>>"
+  | Asr     -> ">>"
+  | Plus    -> "+"
+  | Minus   -> "-"
+  | Mul     -> "*"
+  | Div     -> "/"
+  | Mod     -> "%"
+  
 let str_of_used_stats = function
   | Js_op.Dead_pure ->  "Dead_pure"
   | Dead_non_pure -> "Dead_non_pure"

--- a/jscomp/js_op_util.mli
+++ b/jscomp/js_op_util.mli
@@ -26,6 +26,10 @@ val op_prec : Js_op.binop -> int * int * int
 
 val op_str : Js_op.binop -> string
 
+val op_int_prec : Js_op.int_op -> int * int * int
+
+val op_int_str : Js_op.int_op -> string
+
 val str_of_used_stats : Js_op.used_stats -> string
 
 val update_used_stats : J.ident_info -> Js_op.used_stats -> unit

--- a/jscomp/lam_compile_group.ml
+++ b/jscomp/lam_compile_group.ml
@@ -95,9 +95,13 @@ let compile_group ({filename = file_name; env;} as meta : Lam_stats.meta) (x : L
               J_helper.string "bytes_cat")
 
   (** Special handling for values in [Sys] *)
-  | Single(_, ({name="max_array_length";_} as id) ,_ ),  "sys.ml" ->
-    (* See [js_knowledge] Array size section, can not be expressed by OCaml int *)
+  | Single(_, ({name="max_array_length" | "max_string_length";_} as id) ,_ ),  "sys.ml" ->
+    (* See [js_knowledge] Array size section, can not be expressed by OCaml int,
+       note that casual handling of {!Sys.max_string_length} could result into 
+       negative value which could cause wrong behavior of {!Buffer.create}
+     *)
     Js_output.of_stmt @@ S.const_variable id ~exp:(E.float "4_294_967_295.") 
+                           
   | Single(_, ({name="max_int";_} as id) ,_ ),  ("sys.ml" | "nativeint.ml") ->
     (* See [js_knowledge] Max int section, (2. ** 53. -. 1.;;) can not be expressed by OCaml int *)
     Js_output.of_stmt @@ S.const_variable id ~exp:(E.float "9007199254740991.") 

--- a/jscomp/lam_dispatch_primitive.ml
+++ b/jscomp/lam_dispatch_primitive.ml
@@ -79,7 +79,7 @@ let query (prim : Lam_compile_env.primitive_description)
         end
     |"caml_div_float" -> 
         begin match args with 
-        | [e0;e1] -> E.bin Div e0 e1 
+        | [e0;e1] -> E.float_div e0 e1
         | _ -> assert false 
         end
     |"caml_sub_float" -> 
@@ -181,12 +181,12 @@ let query (prim : Lam_compile_env.primitive_description)
         end
     | "caml_int32_div"| "caml_nativeint_div" -> 
         begin match args with 
-        | [e0;e1] -> E.bin Bor (E.bin Div e0 e1) (E.int 0)
+        | [e0;e1] -> E.int32_div e0 e1
         | _ -> assert false 
         end
     | "caml_int32_mul" | "caml_nativeint_mul"  -> 
         begin match args with 
-        | [e0;e1] -> E.bin Mul e0 e1 
+        | [e0;e1] -> E.int32_mul e0 e1 
         | _ -> assert false 
         end
     | "caml_int32_of_int" | "caml_nativeint_of_int" 
@@ -197,7 +197,7 @@ let query (prim : Lam_compile_env.primitive_description)
          end
     |  "caml_int32_of_float" | "caml_int_of_float"|"caml_nativeint_of_float" -> 
         begin match args with 
-        | [e] -> E.bin Bor e (E.int 0) (* (|) *)
+        | [e] -> E.to_int32 e 
         | _ -> assert false 
         end
     | "caml_int32_to_float" | "caml_int32_to_int" | "caml_nativeint_to_int" 
@@ -213,18 +213,18 @@ let query (prim : Lam_compile_env.primitive_description)
         end
     | "caml_int32_xor" | "caml_nativeint_xor" -> 
         begin match args with 
-        | [e0; e1] -> E.bin Bxor e0 e1 
+        | [e0; e1] -> E.int32_bxor e0 e1 
         | _ -> assert false 
         end
           
     | "caml_int32_and" | "caml_nativeint_and" -> 
         begin match args with 
-        | [e0;e1] -> E.bin Band e0 e1 
+        | [e0;e1] -> E.int32_band e0 e1 
         | _ -> assert false 
         end
     | "caml_int32_or" | "caml_nativeint_or" ->
         begin match args with
-        | [e0;e1] -> E.bin Bor e0 e1 
+        | [e0;e1] -> E.int32_bor e0 e1 
         | _ -> assert false  
         end
     | "caml_le_float" ->
@@ -246,12 +246,12 @@ let query (prim : Lam_compile_env.primitive_description)
         end
     | "caml_neq_float" -> 
         begin match args with 
-        | [e0;e1] -> E.bin NotEqEq e0 e1 
+        | [e0;e1] -> E.float_notequal e0 e1
         | _ -> assert false 
         end
     | "caml_mul_float" -> 
         begin match args with 
-        | [e0; e1] -> E.bin Mul e0 e1 
+        | [e0; e1] -> E.float_mul e0 e1 
         | _ -> assert false  
         end
     | "caml_int64_bits_of_float"

--- a/jscomp/stdlib/pervasives.js
+++ b/jscomp/stdlib/pervasives.js
@@ -45,7 +45,7 @@ function lnot(x) {
   return x ^ -1;
 }
 
-var max_int = (-1 >>> 1);
+var max_int = 2147483647;
 
 var min_int = max_int + 1;
 

--- a/jscomp/stdlib/sys.js
+++ b/jscomp/stdlib/sys.js
@@ -19,7 +19,7 @@ var cygwin = /* false */0;
 
 var max_array_length = 4294967295;
 
-var max_string_length = (word_size / 8 | 0) * max_array_length - 1;
+var max_string_length = 4294967295;
 
 var interactive = [
   0,

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -60,6 +60,8 @@ demo.cmo :
 demo.cmx :
 demo_page.cmo :
 demo_page.cmx :
+empty_obj.cmo :
+empty_obj.cmx :
 equal_exception_test.cmo : ../stdlib/string.cmi mt.cmo ../stdlib/bytes.cmi
 equal_exception_test.cmx : ../stdlib/string.cmx mt.cmx ../stdlib/bytes.cmx
 ext_bytes.cmo : ../stdlib/bytes.cmi
@@ -392,6 +394,8 @@ demo.cmo :
 demo.cmo :
 demo_page.cmo :
 demo_page.cmo :
+empty_obj.cmo :
+empty_obj.cmo :
 equal_exception_test.cmo : ../stdlib/string.cmi mt.cmo ../stdlib/bytes.cmi
 equal_exception_test.cmo : ../stdlib/string.cmo mt.cmo ../stdlib/bytes.cmo
 ext_bytes.cmo : ../stdlib/bytes.cmi

--- a/jscomp/test/buffer_test.js
+++ b/jscomp/test/buffer_test.js
@@ -92,7 +92,7 @@ var suites = [
   suites_002
 ];
 
-Mt.from_suites("buffer", suites);
+Mt.from_suites("buffer_test.ml", suites);
 
 exports.v = v;
 exports.bytes_equal = bytes_equal;

--- a/jscomp/test/buffer_test.ml
+++ b/jscomp/test/buffer_test.ml
@@ -25,4 +25,4 @@ let suites = [
             )
 ]
 open Mt 
-;; from_suites "buffer" suites
+;; from_suites __FILE__ suites

--- a/jscomp/test/empty_obj.d.ts
+++ b/jscomp/test/empty_obj.d.ts
@@ -1,0 +1,2 @@
+export var v: any ;
+

--- a/jscomp/test/empty_obj.js
+++ b/jscomp/test/empty_obj.js
@@ -1,0 +1,16 @@
+// Generated CODE, PLEASE EDIT WITH CARE
+"use strict";
+var CamlinternalOO = require("../stdlib/camlinternalOO");
+
+var $$class = CamlinternalOO.create_table(0);
+
+function obj_init() {
+  return CamlinternalOO.create_object_opt(0, $$class);
+}
+
+CamlinternalOO.init_class($$class);
+
+var v = obj_init(0);
+
+exports.v = v;
+/* class Not a pure module */

--- a/jscomp/test/empty_obj.ml
+++ b/jscomp/test/empty_obj.ml
@@ -1,0 +1,2 @@
+let v = object 
+end

--- a/jscomp/test/test_per.js
+++ b/jscomp/test/test_per.js
@@ -46,7 +46,7 @@ function lnot(x) {
   return x ^ -1;
 }
 
-var max_int = (-1 >>> 1);
+var max_int = 2147483647;
 
 var min_int = max_int + 1;
 


### PR DESCRIPTION
Squashed commits:
[72476aa] fix {!Sys.max_string_length}
[e628e34] micro-optimize band (when its inner is `|`) (+1 squashed commit)
Squashed commits:
[f9bf7d1] micro-optimize int32_lsr (+1 squashed commit)
Squashed commits:
[918fe00] now it works, there is a bug in precedence printer, tweak and micro-optimize it later (+3 squashed commits)
Squashed commits:
[6ed0c1b] using js integer semantics for js ir
1. this is consistent with what we did
2. easy for optimizations, we don't want to add another JS IR after all, if we do too much compilation in [js_dump], that will
make some simple cases hard to optimize like [ (x >>> (i * 8) | 0 )  & 255]
[935b94f] migrate div to int32_div
[1120b77] prepare int 32 operation support