### PR TITLE
when primitive is missing, we do `console.error` for a better error message

### DIFF
--- a/jscomp/ext_log.mli
+++ b/jscomp/ext_log.mli
@@ -31,6 +31,12 @@
 
 type ('a,'b) logging =   ('a -> 'b, Format.formatter, unit, unit, unit, unit) format6 -> 'a -> 'b
 
+(* FIXM: below does not work 
+   {[
+     err __LOC__ "hi"     
+   ]}   
+   
+*)
 val err : string -> ('a,'b) logging
 val ierr : bool -> string -> ('a,'b) logging 
 val warn : string -> ('a,'b) logging

--- a/jscomp/j.ml
+++ b/jscomp/j.ml
@@ -142,6 +142,10 @@ and expression_desc =
      ]}     
   *)      
   | Dump of Js_op.level * expression list
+  (* TODO: 
+     add 
+     {[ Assert of bool * expression ]}     
+  *)              
     (* to support 
        val log1 : 'a -> unit
        val log2 : 'a -> 'b -> unit 

--- a/jscomp/js_fold.ml
+++ b/jscomp/js_fold.ml
@@ -156,6 +156,10 @@ class virtual fold =
      {[ 'undefined'
      ]}     
   *)
+                 (* TODO: 
+     add 
+     {[ Assert of bool * expression ]}     
+  *)
                  (* to support 
        val log1 : 'a -> unit
        val log2 : 'a -> 'b -> unit 

--- a/jscomp/js_helper.ml
+++ b/jscomp/js_helper.ml
@@ -598,8 +598,6 @@ module Exp = struct
   let unknown_lambda ?(comment="unknown")  (lam : Lambda.lambda ) : t = 
        str ~pure:false ~comment (Lam_util.string_of_lambda lam)
 
-  let unknown_primitive ?(comment="unknown") (p : Lambda.primitive) : t = 
-    str ~pure:false ~comment (Lam_util.string_of_primitive p) 
 
   let unit  () = int ~comment:"()" 0;; (* TODO: add a comment *)
 

--- a/jscomp/js_helper.mli
+++ b/jscomp/js_helper.mli
@@ -211,8 +211,6 @@ module Exp : sig
 
   val unknown_lambda : ?comment:string -> Lambda.lambda -> t
 
-  val unknown_primitive : ?comment:string -> Lambda.primitive -> t
-  
   val unit :  unit -> t
   (** [unit] in ocaml will be compiled into [0]  in js *)
 

--- a/jscomp/js_map.ml
+++ b/jscomp/js_map.ml
@@ -169,6 +169,10 @@ class virtual map =
      {[ 'undefined'
      ]}     
   *)
+                 (* TODO: 
+     add 
+     {[ Assert of bool * expression ]}     
+  *)
                  (* to support 
        val log1 : 'a -> unit
        val log2 : 'a -> 'b -> unit 

--- a/jscomp/lam_compile_primitive.ml
+++ b/jscomp/lam_compile_primitive.ml
@@ -45,135 +45,135 @@ let translate
   | Pfield i -> 
     begin match args with 
       | [ e ]  -> Js_of_lam_block.field e i (* Invariant depends on runtime *)
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | (Pnegint | Pnegbint _ | Pnegfloat) ->
     begin match args with
       | [ e ] -> E.int32_minus (E.int 0)  e 
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Pnot ->
     begin match args with
       | [e] ->  E.not  e 
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Poffsetint n ->
     begin match args with
       | [e] ->  E.int32_add  e (E.int n) 
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Poffsetref n ->
     begin match args with
       | [e] -> 
         let v = (Js_of_lam_block.field e 0) in
         E.assign  v (E.int32_add v (E.int n))
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Paddint | Paddbint _
     ->
     begin match args with
       | [e1;e2] ->
         E.int32_add  e1  e2
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
  | Paddfloat
      -> 
     begin match args with
       | [e1;e2] ->
         E.float_add  e1  e2
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Psubint | Psubbint _ 
     -> 
     begin match args with
       | [e1;e2] ->
           E.int32_minus   e1  e2
-      | _ -> E.unknown_primitive prim end
+      | _ -> assert false end
   | Psubfloat
     ->
       begin match args with
       | [e1;e2] ->
           E.float_minus   e1  e2
-      | _ -> E.unknown_primitive prim 
+      | _ -> assert false 
       end
   | Pmulint | Pmulbint _ 
     ->
     begin match args with
       | [e1; e2]  ->
         E.int32_mul  e1  e2
-      | _ -> E.unknown_primitive prim 
+      | _ -> assert false 
     end
   | Pmulfloat 
     -> 
       begin match args with
       | [e1; e2]  ->
           E.float_mul  e1  e2
-      | _ -> E.unknown_primitive prim 
+      | _ -> assert false 
       end
   | Pdivfloat -> 
     begin match args with  (* TODO: see ocamljs -- assertion*)
       | [e1;e2] -> E.float_div  e1  e2
-      | _ -> E.unknown_primitive prim end
+      | _ -> assert false end
   | (  Pdivint | Pdivbint _)->
     begin match args with  (* TODO: see ocamljs -- assertion*)
       | [e1;e2] ->
         E.int32_div e1 e2  (** 32 bits  *)
-      | _ -> E.unknown_primitive prim end
+      | _ -> assert false end
   | Pmodint | Pmodbint _ ->
     begin match args with
       | [e1; e2] ->
         E.int32_mod   e1  e2
-      | _ -> E.unknown_primitive prim 
+      | _ -> assert false 
     end
   | Plslint | Plslbint _ ->
     begin match args with
       | [e1;e2] ->
         E.int32_lsl e1  e2
-      | _ -> E.unknown_primitive prim 
+      | _ -> assert false 
     end
   | (Plsrint | Plsrbint _) ->
     begin match args with
       | [e1; e2] ->
         E.int32_lsr   e1  e2
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | (Pasrint | Pasrbint _) ->
     begin match args with
       | [e1;e2] ->
         E.int32_asr  e1  e2
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
 
   | Pandint | Pandbint _->
     begin match args with
       | [e1;e2] ->
         E.int32_band  e1  e2
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Porint | Porbint _ ->
     begin match args with
       | [e1;e2] ->
         E.int32_bor  e1  e2
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Pxorint | Pxorbint _ ->
     begin match args with
       | [e1;e2] ->
         E.int32_bxor  e1  e2
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
 
   | Psequand -> (* TODO: rhs is possibly a tail call *)
     begin match args with
       | [e1;e2] ->
         E.and_   e1  e2
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Psequor -> (* TODO: rhs is possibly a tail call *)
     begin match args with
       | [e1;e2] ->
         E.or_  e1  e2
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Pisout -> 
     begin match args with 
@@ -188,27 +188,27 @@ let translate
          in the first step [ (x - 1) > 1 or ( x - 1 ) < 0 ]
       *)
       | [range; e] -> E.is_out e range
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Pidentity ->
     begin 
-      match args with [e] -> e | _ -> E.unknown_primitive prim  
+      match args with [e] -> e | _ -> assert false  
     end
   | Pmark_ocaml_object -> 
     begin 
       match args with 
       | [e] ->  E.tag_ml_obj e 
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Pchar_of_int -> 
     begin match args with 
       | [e] -> Js_of_lam_string.caml_char_of_int e 
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Pchar_to_int -> 
     begin match args with 
       | [e] -> Js_of_lam_string.caml_char_to_int e 
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Pbytes_of_string -> 
     begin 
@@ -218,23 +218,23 @@ let translate
       *)
       match args with 
       |[e] -> Js_of_lam_string.bytes_of_string e
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Pbytes_to_string  -> 
     begin 
       match args with 
       |[e] -> Js_of_lam_string.bytes_to_string e 
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
   | Pstringlength ->
     begin match args with
       | [e] -> E.string_length e 
-      | _ -> E.unknown_primitive prim 
+      | _ -> assert false 
     end
   | Pbyteslength  -> 
     begin match args with
       | [e] -> E.bytes_length e 
-      | _ -> E.unknown_primitive prim 
+      | _ -> assert false 
     end
   (* This should only be Pbyteset(u|s), which in js, is an int array 
      Bytes is an int array in javascript
@@ -245,15 +245,21 @@ let translate
       | [e;e0;e1] -> decorate_side_effect cxt 
             (Js_of_lam_string.set_byte e e0 e1)
 
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
       end
   | Pstringsetu 
-  | Pstringsets -> E.unknown_primitive prim (* string is immutable *)
+  | Pstringsets ->
+    begin
+      Ext_log.err __LOC__ "string is immutable, %s is not available" "string.unsafe_get" ;     
+      assert false (* string is immutable *)  
+    end
+
+
   | Pbytesrefu 
   | Pbytesrefs ->
       begin match args with
       | [e;e1] -> Js_of_lam_string.ref_byte e e1
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
       end
 
    (* For bytes and string, they both return [int] in ocaml 
@@ -265,13 +271,13 @@ let translate
   | Pstringrefs ->
       begin match args with
       | [e;e1] -> Js_of_lam_string.ref_string e e1 
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
       end
   | Pignore -> 
       begin 
         match args with 
         | [e] -> e
-        | _ -> E.unknown_primitive prim 
+        | _ -> assert false 
       end
   | Pbintcomp (_, cmp)
   | Pfloatcomp cmp 
@@ -282,7 +288,7 @@ let translate
       *)
       match args with 
       | [e1;e2] -> E.int_comp cmp e1 e2
-      | _ -> E.unknown_primitive prim 
+      | _ -> assert false 
     end
         (* List --> stamp = 0 
            Assert_false --> stamp = 26 
@@ -295,7 +301,7 @@ let translate
     Lam_compile_global.get_exp (QueryGlobal (i,env,false))
   
     (** only when Lapply -> expand = true*)
-  | Praise _raise_kind -> E.unknown_primitive prim (* handled before here *)
+  | Praise _raise_kind -> assert false (* handled before here *)
   | Prevapply _  -> 
     begin 
       match args with 
@@ -306,33 +312,33 @@ let translate
     begin 
       match args with 
       | [f; arg] -> E.call f [arg]
-      | _ -> E.unknown_primitive prim 
+      | _ -> assert false 
     end
-  | Ploc kind ->   E.unknown_primitive prim (* already compiled away here*)
+  | Ploc kind ->   assert false (* already compiled away here*)
   | Pintoffloat -> 
     begin
       match args with 
       | [e] -> e 
-      | _ -> E.unknown_primitive prim 
+      | _ -> assert false 
     end
 (* Runtime encoding relevant *)
   | Parraylength _  -> 
       begin match args with 
       | [e] -> E.array_length e 
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
       end
   | Psetfield (i, _) -> 
       begin match args with 
       | [e0;e1] ->  (** RUNTIME *)
           decorate_side_effect cxt (Js_of_lam_block.set_field e0 i e1)
             (*TODO: get rid of [E.unit ()]*)
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
       end
   | Psetfloatfield i -> (** RUNTIME --  RETURN VALUE SHOULD BE UNIT *)
       begin 
         match args with 
         | [e;e0] -> decorate_side_effect cxt (Js_of_lam_float_record.set_double_field e i e0 ) 
-        | _ -> E.unknown_primitive prim
+        | _ -> assert false
       end
 
 
@@ -340,13 +346,13 @@ let translate
       begin 
         match args with 
         | [e] -> Js_of_lam_float_record.get_double_feild e i 
-        | _ -> E.unknown_primitive prim 
+        | _ -> assert false 
       end
   | Parrayrefu _kind
   | Parrayrefs _kind ->  
       begin match args with
       | [e;e1] -> Js_of_lam_array.ref_array e e1 (* Todo: Constant Folding *)
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
       end
   | Pmakearray kind -> 
       Js_of_lam_array.make_array Mutable kind args 
@@ -354,21 +360,21 @@ let translate
   | Parraysets _kind -> 
       begin match args with (* wrong*)
       | [e;e0;e1] -> decorate_side_effect cxt @@ Js_of_lam_array.set_array  e e0 e1
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
       end
   | Pbintofint _
   | Pintofbint _
   | Pfloatofint -> 
       begin match args with 
       | [e] -> e 
-      | _ -> E.unknown_primitive prim 
+      | _ -> assert false 
       end
   | Pabsfloat -> 
     begin match args with 
       | [e] ->
         E.math "abs" [e]
         (* GCC treat built-ins like Math in a dirfferent way*)
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
       end
   | Pccall ({prim_attributes ; prim_ty } as prim) -> 
       Lam_compile_external_call.translate cxt prim args 
@@ -378,7 +384,7 @@ let translate
       match args with 
       | [e] ->  E.is_type_number e 
 
-      | _ ->   E.unknown_primitive prim
+      | _ ->   assert false
     end
   | Pctconst ct -> 
     begin
@@ -399,9 +405,11 @@ let translate
     begin 
       match args with 
       | [e0] -> e0 (* TODO: int64 is not supported yet *)
-      | _ -> E.unknown_primitive prim
+      | _ -> assert false
     end
-  | Psetglobal _  ->  E.unknown_primitive prim (* already handled *)
+  | Psetglobal _  -> 
+    assert false (* already handled *)
+    (* assert false *)
   | Pduprecord ( (Record_regular | Record_float),  _) -> 
     (* this is due to we encode record as an array, it is going to change
        if we have another encoding       
@@ -429,4 +437,12 @@ let translate
   | Pbigstring_set_64 _
   | Pbswap16
   | Pbbswap _
-  | Pint_as_pointer  -> E.unknown_primitive prim
+  | Pint_as_pointer  -> 
+      let comment = "Missing primitve" in       
+      let s = Lam_util.string_of_primitive prim in
+      let warn = Printf.sprintf  "%s: %s\n" comment s in
+      Ext_log.warn __LOC__ "%s"  warn;
+      (*we dont use [throw] here, since [throw] is an statement  *)        
+      E.dump  Error [ E.str warn]
+
+

--- a/jscomp/lam_dispatch_primitive.ml
+++ b/jscomp/lam_dispatch_primitive.ml
@@ -34,20 +34,17 @@ There are two things we need consider:
 *)
 let query (prim : Lam_compile_env.primitive_description) 
     (args : J.expression list) : J.expression  =
-  let module X = struct exception NA end in 
-  try 
-    let v = 
-      begin match prim.prim_name  with 
-      | "caml_gc_stat" | "caml_gc_quick_stat"  -> 
-        (** 
-            external caml_gc_stat : unit -> stat 
-            external caml_gc_quick_stat : unit -> stat 
-            
-            Need check stat concrete representation 
-            all fields are either [float ]
-            It even does not make sense to have GC module 
-         *)
-          Js_of_lam_record.make Immutable E.[ 
+  begin match prim.prim_name  with 
+    | "caml_gc_stat" | "caml_gc_quick_stat"  -> 
+      (** 
+          external caml_gc_stat : unit -> stat 
+          external caml_gc_quick_stat : unit -> stat 
+
+          Need check stat concrete representation 
+          all fields are either [float ]
+          It even does not make sense to have GC module 
+      *)
+      Js_of_lam_record.make Immutable E.[ 
           "minor_words" , zero_float_lit;
           "promoted_words", zero_float_lit;
           "major_words", zero_float_lit;
@@ -64,196 +61,196 @@ let query (prim : Lam_compile_env.primitive_description)
           "compactions", int 0;
           "top_heap_words", int 0;
           "stack_size" , int 0;
-          ]
+        ]
 
-        
-        
+
+
     | "caml_abs_float" -> 
-        E.math "abs" args 
+      E.math "abs" args 
     | "caml_acos_float" -> 
-        E.math "acos" args 
+      E.math "acos" args 
     |  "caml_add_float" -> 
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.float_add e0 e1 (** TODO float plus*)
         | _ -> assert false
-        end
+      end
     |"caml_div_float" -> 
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.float_div e0 e1
         | _ -> assert false 
-        end
+      end
     |"caml_sub_float" -> 
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.float_minus e0 e1 
         | _ -> assert false 
-        end
+      end
     | "caml_eq_float" -> 
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.float_equal e0 e1 
         | _ -> assert false 
-        end
+      end
     | "caml_ge_float"  ->
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.float_comp Cge e0 e1
         | _ -> assert false 
-        end
+      end
     |"caml_gt_float"  ->
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.float_comp Cgt  e0 e1
         | _ -> assert false 
-        end
+      end
     | "caml_tan_float"  ->
-        E.math "tan" args 
+      E.math "tan" args 
     | "caml_tanh_float"  ->
-       E.math "tanh" args 
+      E.math "tanh" args 
     | "caml_asin_float"  -> 
-       E.math "asin" args 
+      E.math "asin" args 
     | "caml_atan2_float" -> 
-       E.math "atan2" args
+      E.math "atan2" args
     | "caml_atan_float" -> 
-       E.math "atan" args 
+      E.math "atan" args 
     | "caml_ceil_float" -> 
-       E.math "ceil" args 
+      E.math "ceil" args 
     | "caml_cos_float" -> 
-       E.math "cos" args 
+      E.math "cos" args 
     | "caml_cosh_float" -> 
-       E.math "cosh" args
+      E.math "cosh" args
     | "caml_exp_float" -> 
-       E.math "exp" args
+      E.math "exp" args
     | "caml_sin_float" -> 
-       E.math "sin" args
+      E.math "sin" args
     | "caml_sinh_float"-> 
-       E.math "sinh" args
+      E.math "sinh" args
     | "caml_sqrt_float" -> 
-       E.math "sqrt" args
+      E.math "sqrt" args
 
 
     | "caml_float_of_int" -> 
-        begin match args with 
+      begin match args with 
         | [e] -> e 
         | _ -> assert false 
-        end
+      end
     | "caml_floor_float" ->
-       E.math "floor" args 
+      E.math "floor" args 
     | "caml_log_float" -> 
-        E.math "log" args 
+      E.math "log" args 
     | "caml_log10_float" -> 
-       E.math "log10" args 
+      E.math "log10" args 
     | "caml_log1p_float" -> 
-       E.math "log1p" args 
+      E.math "log1p" args 
     | "caml_power_float"  -> 
-       E.math "pow" args
+      E.math "pow" args
     |  "caml_make_float_vect" -> 
-        E.new_ (E.js_global "Array") args 
+      E.new_ (E.js_global "Array") args 
 
 
     | "caml_array_append" -> 
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.array_append e0 e1
         | _ ->  assert false 
-        end
+      end
 
     | "caml_array_get"
     | "caml_array_get_addr"
     | "caml_array_get_float"
     | "caml_array_unsafe_get"
     | "caml_array_unsafe_get_float" -> 
-         begin match args with 
-         | [e0;e1] -> Js_of_lam_array.ref_array e0 e1
-         | _ -> assert false
-         end
+      begin match args with 
+        | [e0;e1] -> Js_of_lam_array.ref_array e0 e1
+        | _ -> assert false
+      end
     | "caml_array_set"
     | "caml_array_set_addr"
     | "caml_array_set_float"
     | "caml_array_unsafe_set"
     | "caml_array_unsafe_set_addr"
     | "caml_array_unsafe_set_float" -> 
-         begin match args with 
-         | [e0;e1;e2] -> 
-             Js_of_lam_array.set_array e0 e1 e2
-         | _ -> assert false
-         end
+      begin match args with 
+        | [e0;e1;e2] -> 
+          Js_of_lam_array.set_array e0 e1 e2
+        | _ -> assert false
+      end
 
     | "caml_int32_add"|"caml_nativeint_add" -> 
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.int32_add e0 e1 
         | _ -> assert false 
-        end
+      end
     | "caml_int32_div"| "caml_nativeint_div" -> 
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.int32_div e0 e1
         | _ -> assert false 
-        end
+      end
     | "caml_int32_mul" | "caml_nativeint_mul"  -> 
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.int32_mul e0 e1 
         | _ -> assert false 
-        end
+      end
     | "caml_int32_of_int" | "caml_nativeint_of_int" 
-       | "caml_nativeint_of_int32" -> 
-         begin match args with 
-         | [e] -> e 
-         | _ -> assert false 
-         end
-    |  "caml_int32_of_float" | "caml_int_of_float"|"caml_nativeint_of_float" -> 
-        begin match args with 
-        | [e] -> E.to_int32 e 
-        | _ -> assert false 
-        end
-    | "caml_int32_to_float" | "caml_int32_to_int" | "caml_nativeint_to_int" 
-    |  "caml_nativeint_to_float"| "caml_nativeint_to_int32" -> 
-        begin match args with 
+    | "caml_nativeint_of_int32" -> 
+      begin match args with 
         | [e] -> e 
         | _ -> assert false 
-        end
+      end
+    |  "caml_int32_of_float" | "caml_int_of_float"|"caml_nativeint_of_float" -> 
+      begin match args with 
+        | [e] -> E.to_int32 e 
+        | _ -> assert false 
+      end
+    | "caml_int32_to_float" | "caml_int32_to_int" | "caml_nativeint_to_int" 
+    |  "caml_nativeint_to_float"| "caml_nativeint_to_int32" -> 
+      begin match args with 
+        | [e] -> e 
+        | _ -> assert false 
+      end
     | "caml_int32_sub"|"caml_nativeint_sub" ->
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.int32_minus e0 e1 
         | _ -> assert false 
-        end
+      end
     | "caml_int32_xor" | "caml_nativeint_xor" -> 
-        begin match args with 
+      begin match args with 
         | [e0; e1] -> E.int32_bxor e0 e1 
         | _ -> assert false 
-        end
-          
+      end
+
     | "caml_int32_and" | "caml_nativeint_and" -> 
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.int32_band e0 e1 
         | _ -> assert false 
-        end
+      end
     | "caml_int32_or" | "caml_nativeint_or" ->
-        begin match args with
+      begin match args with
         | [e0;e1] -> E.int32_bor e0 e1 
         | _ -> assert false  
-        end
+      end
     | "caml_le_float" ->
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.float_comp Cle e0 e1 
         | _ -> assert false 
-        end
+      end
     | "caml_lt_float" ->
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.float_comp Clt e0 e1 
         | _ -> assert false 
-        end
+      end
     |  "caml_neg_float" -> 
-        begin match args with 
+      begin match args with 
         | [e] -> 
-            (** TODO: use float.. *)
-            E.int32_minus (E.int 0) e 
+          (** TODO: use float.. *)
+          E.int32_minus (E.int 0) e 
         | _ -> assert false
-        end
+      end
     | "caml_neq_float" -> 
-        begin match args with 
+      begin match args with 
         | [e0;e1] -> E.float_notequal e0 e1
         | _ -> assert false 
-        end
+      end
     | "caml_mul_float" -> 
-        begin match args with 
+      begin match args with 
         | [e0; e1] -> E.float_mul e0 e1 
         | _ -> assert false  
-        end
+      end
     | "caml_int64_bits_of_float"
     | "caml_int64_float_of_bits"
     | "caml_classify_float"
@@ -265,75 +262,75 @@ let query (prim : Lam_compile_env.primitive_description)
     | "caml_expm1_float"
     | "caml_hypot_float"
 
-     ->
-        E.runtime_call Js_helper.float prim.prim_name args
+      ->
+      E.runtime_call Js_helper.float prim.prim_name args
     | "caml_fmod_float" 
-        (* float module like js number module *)      
-        ->      
-        begin match args with 
+      (* float module like js number module *)      
+      ->      
+      begin match args with 
         | [e0;e1] -> E.float_mod e0 e1
         | _ -> assert false 
-        end
-        
+      end
+
     | "caml_string_equal" 
       -> 
-        begin match args with 
+      begin match args with 
         | [e0; e1] -> E.string_equal e0 e1 
         | _ -> assert false 
-        end
+      end
     | "caml_string_notequal"
       -> 
-        begin match args with 
+      begin match args with 
         | [e0; e1] -> E.string_comp NotEqEq e0 e1
-              (** TODO: convert to ocaml ones*)
+        (** TODO: convert to ocaml ones*)
         | _ -> assert false 
-        end
+      end
     | "caml_string_lessequal"
-        -> 
-          begin 
-            match args with 
-            | [e0; e1] 
-              -> 
-                E.string_comp Le e0 e1
-            | _ -> assert false 
-          end
+      -> 
+      begin 
+        match args with 
+        | [e0; e1] 
+          -> 
+          E.string_comp Le e0 e1
+        | _ -> assert false 
+      end
     | "caml_string_lessthan"
-        -> 
-          begin match args with 
-          | [e0; e1] 
-            -> 
-              E.string_comp Lt e0 e1
-          | _ -> assert false 
-          end
+      -> 
+      begin match args with 
+        | [e0; e1] 
+          -> 
+          E.string_comp Lt e0 e1
+        | _ -> assert false 
+      end
     | "caml_string_greaterequal"
-        -> 
-          begin match args with 
-          | [e0; e1] 
-            -> 
-              E.string_comp Ge  e0 e1
-          | _ -> assert false 
-          end
+      -> 
+      begin match args with 
+        | [e0; e1] 
+          -> 
+          E.string_comp Ge  e0 e1
+        | _ -> assert false 
+      end
     | "caml_string_greaterthan"
-        -> 
-          begin match args with 
-          | [e0; e1] 
-            -> 
-              E.string_comp Gt  e0 e1
-          | _ -> assert false 
-          end
+      -> 
+      begin match args with 
+        | [e0; e1] 
+          -> 
+          E.string_comp Gt  e0 e1
+        | _ -> assert false 
+      end
     | "caml_create_string" -> 
-        (* Note that for invalid range, JS raise an Exception RangeError, 
-          here in OCaml it's [Invalid_argument], we have to preserve this semantics.
-            Also, it's creating a [bytes] which is a js array actually.
-         *)
-        begin match args with
+      (* Note that for invalid range, JS raise an Exception RangeError, 
+         here in OCaml it's [Invalid_argument], we have to preserve this semantics.
+          Also, it's creating a [bytes] which is a js array actually.
+      *)
+      begin match args with
         | [{expression_desc = Number (Int {i; _}); _} as v] 
           when i >= 0 -> 
-            E.uninitialized_array v 
-              (* TODO: inline and spits out a warning when i is negative *)
+          E.uninitialized_array v 
+        (* TODO: inline and spits out a warning when i is negative *)
         | _ -> 
-            E.runtime_call Js_helper.string prim.prim_name args
-        end
+          E.runtime_call Js_helper.string prim.prim_name args
+      end
 
     | "caml_string_get"
     | "caml_string_compare"
@@ -346,31 +343,31 @@ let query (prim : Lam_compile_env.primitive_description)
     | "caml_blit_string" 
     | "caml_blit_bytes"
       -> 
-        E.runtime_call Js_helper.string prim.prim_name args
+      E.runtime_call Js_helper.string prim.prim_name args
 
     | "caml_register_named_value" -> 
-        (**
-           callback.ml
-           {[ external register_named_value : string -> Obj.t -> unit
-                              = "caml_register_named_value" ]}
+      (**
+         callback.ml
+         {[ external register_named_value : string -> Obj.t -> unit
+           = "caml_register_named_value" ]}
 
-           See the manual chap19, Interfacing C with OCaml
+         See the manual chap19, Interfacing C with OCaml
 
-           {[
+         {[
            let f x = print_string "f is applied to "; print_int x; print_newline()
            let _ = Callback.register "test function" f
-           ]}
+         ]}
 
-           On the C side 
-           {[
+         On the C side 
+         {[
            let f x = print_string "f is applied to "; print_int x; print_newline()
            let _ = Callback.register "test function" f
-           ]}
+         ]}
 
-           [caml_named_value] is a c primitive but not OCaml/runtimedef.ml, so we don't needs
-           handle it 
-         *)
-        E.unit ()
+         [caml_named_value] is a c primitive but not OCaml/runtimedef.ml, so we don't needs
+         handle it 
+      *)
+      E.unit ()
     | "caml_gc_compaction" 
     | "caml_gc_full_major" 
     | "caml_gc_major" 
@@ -388,91 +385,91 @@ let query (prim : Lam_compile_env.primitive_description)
     | "caml_convert_raw_backtrace" 
     | "caml_get_current_callstack"
       -> E.unit ()
-             (* unit -> unit 
-                _ -> unit  
-                major_slice : int -> int 
-              *)
+    (* unit -> unit 
+       _ -> unit  
+       major_slice : int -> int 
+    *)
     |"caml_gc_counters" ->
-        Js_of_lam_tuple.make E.[ zero_float_lit; zero_float_lit; zero_float_lit]
-          (* unit -> (float * float * float) *)
+      Js_of_lam_tuple.make E.[ zero_float_lit; zero_float_lit; zero_float_lit]
+    (* unit -> (float * float * float) *)
 
     |  "caml_gc_get" ->  
-        (* unit -> Gc.control*)
-        E.arr NA [E.int 0; 
-                  E.int ~comment:"minor_heap_size" 0 ;
-                  E.int ~comment:"major_heap_increment" 0 ;
-                  E.int ~comment:"space_overhead" 0; 
-                  E.int ~comment:"verbose" 0; (* TODO*)
-                  E.int ~comment:"max_overhead" 0;
-                  E.int ~comment:"stack_limit" 0;
-                  E.int ~comment:"allocation_policy" 0]
+      (* unit -> Gc.control*)
+      E.arr NA [E.int 0; 
+                E.int ~comment:"minor_heap_size" 0 ;
+                E.int ~comment:"major_heap_increment" 0 ;
+                E.int ~comment:"space_overhead" 0; 
+                E.int ~comment:"verbose" 0; (* TODO*)
+                E.int ~comment:"max_overhead" 0;
+                E.int ~comment:"stack_limit" 0;
+                E.int ~comment:"allocation_policy" 0]
     | "caml_set_oo_id" 
       ->
-        (** ATT: relevant to how exception is encoded in OCaml 
-            IDea: maybe we can delay compile primitive into js?
-            benefit: 
-            less code side when serialzation, and more knowledge in jsir
-         *)
+      (** ATT: relevant to how exception is encoded in OCaml 
+          IDea: maybe we can delay compile primitive into js?
+          benefit: 
+          less code side when serialzation, and more knowledge in jsir
+      *)
 
-        begin match args with 
+      begin match args with 
         | [  { expression_desc  = Array (
-               [ tag; str; {expression_desc = J.Number (Int { i = 0; _}); _} ],flag);
-               _} as v 
-           ] 
+            [ tag; str; {expression_desc = J.Number (Int { i = 0; _}); _} ],flag);
+            _} as v 
+          ] 
           -> 
-            (* Caml_exceptions.caml_oo_last_id++*)
-             {v with expression_desc  =
-              J.Array
-                ([ tag; str ; 
-                  E.prefix_inc
-                    (E.runtime_var_vid
-                       Js_helper.exceptions
-                       "caml_oo_last_id") 
-                   ], flag)
-            }
+          (* Caml_exceptions.caml_oo_last_id++*)
+          {v with expression_desc  =
+                    J.Array
+                      ([ tag; str ; 
+                         E.prefix_inc
+                           (E.runtime_var_vid
+                              Js_helper.exceptions
+                              "caml_oo_last_id") 
+                       ], flag)
+          }
         | _ ->  
-            E.runtime_call Js_helper.exceptions prim.prim_name args 
-        end
+          E.runtime_call Js_helper.exceptions prim.prim_name args 
+      end
 
     | "caml_sys_const_big_endian" -> 
-        (** return false *)
-        E.bool Sys.big_endian
+      (** return false *)
+      E.bool Sys.big_endian
     | "caml_sys_const_word_size" -> 
-        E.int Sys.word_size
-         (** TODO: How it will affect program behavior *)
+      E.int Sys.word_size
+    (** TODO: How it will affect program behavior *)
     | "caml_sys_const_ostype_cygwin" -> E.false_ 
     | "caml_sys_const_ostype_win32" -> E.false_ 
     | "caml_sys_const_ostype_unix" -> E.true_
     | "caml_is_js" -> E.true_
     | "caml_sys_get_config" ->
-        (** No cross compilation *)
-        Js_of_lam_tuple.make [E.str Sys.os_type; E.int Sys.word_size; 
-                              E.bool Sys.big_endian ]
+      (** No cross compilation *)
+      Js_of_lam_tuple.make [E.str Sys.os_type; E.int Sys.word_size; 
+                            E.bool Sys.big_endian ]
     | "caml_sys_get_argv" -> 
-        (** TODO: refine
-            Inlined here is helpful for DCE
-         *)
-        Js_of_lam_tuple.make [E.str "cmd"; E.arr NA [] ]
+      (** TODO: refine
+          Inlined here is helpful for DCE
+      *)
+      Js_of_lam_tuple.make [E.str "cmd"; E.arr NA [] ]
     | "caml_sys_time"
 
     | "caml_sys_random_seed"
     | "caml_sys_getenv"
     | "caml_sys_system_command" -> 
-        E.runtime_call Js_helper.sys prim.prim_name args 
+      E.runtime_call Js_helper.sys prim.prim_name args 
     | "caml_lex_engine"
     | "caml_new_lex_engine"
     | "caml_parse_engine"
     | "caml_set_parser_trace" -> 
-        E.runtime_call Js_helper.lex_parse prim.prim_name args 
+      E.runtime_call Js_helper.lex_parse prim.prim_name args 
 
     | "caml_array_sub"
     | "caml_array_concat"
-        (*external concat: 'a array list -> 'a array 
-          Not good for inline *)
+    (*external concat: 'a array list -> 'a array 
+      Not good for inline *)
 
     | "caml_array_blit"
     | "caml_make_vect" -> 
-        E.runtime_call Js_helper.array prim.prim_name args 
+      E.runtime_call Js_helper.array prim.prim_name args 
 
     | "caml_ml_open_descriptor_in" 
     | "caml_ml_open_descriptor_out"
@@ -480,35 +477,35 @@ let query (prim : Lam_compile_env.primitive_description)
     | "caml_ml_output" 
     | "caml_ml_input_char"
       -> 
-        E.runtime_call Js_helper.io prim.prim_name args 
+      E.runtime_call Js_helper.io prim.prim_name args 
 
     | "caml_obj_dup" -> 
-          (** Note currently is an Array copy function, this is tightly coupled with 
-              how record, tuple encoded in JS.
-              Here we only inline constant cases, since this semantics should be preserved 
-              no matter how we represent objects, we don't inline it just for future
-           *)
-        begin 
-          match args with 
-          | [ a ] when Js_helper.is_constant a ->  a 
-          | _ -> 
-              E.runtime_call Js_helper.obj_runtime prim.prim_name args 
-        end
+      (** Note currently is an Array copy function, this is tightly coupled with 
+          how record, tuple encoded in JS.
+          Here we only inline constant cases, since this semantics should be preserved 
+          no matter how we represent objects, we don't inline it just for future
+      *)
+      begin 
+        match args with 
+        | [ a ] when Js_helper.is_constant a ->  a 
+        | _ -> 
+          E.runtime_call Js_helper.obj_runtime prim.prim_name args 
+      end
     | "caml_obj_block" -> 
-        (** TODO: Optimize  for [CamlinternalOO] input 
-            external new_block : tag:int -> size:int  -> t = "caml_obj_block"
-            Note that we don't need initialize its content anyway
-            TODO: more optimizations later
-            ATTENTION: This optmization is coupled with memory layout
-         *)
-        begin match args with 
-          | [ {expression_desc = Number (Int { i = tag; _}); _ }; 
-              {expression_desc = Number (Int { i = 0;_}); _} ] ->
-              E.arr Immutable [E.int tag] (** size 0*)
-          | _ -> 
-              E.runtime_call Js_helper.obj_runtime prim.prim_name args 
+      (** TODO: Optimize  for [CamlinternalOO] input 
+          external new_block : tag:int -> size:int  -> t = "caml_obj_block"
+          Note that we don't need initialize its content anyway
+          TODO: more optimizations later
+          ATTENTION: This optmization is coupled with memory layout
+      *)
+      begin match args with 
+        | [ {expression_desc = Number (Int { i = tag; _}); _ }; 
+            {expression_desc = Number (Int { i = 0;_}); _} ] ->
+          E.arr Immutable [E.int tag] (** size 0*)
+        | _ -> 
+          E.runtime_call Js_helper.obj_runtime prim.prim_name args 
 
-        end
+      end
     | "caml_obj_is_block"
     | "caml_obj_tag"
     | "caml_obj_set_tag"
@@ -516,7 +513,7 @@ let query (prim : Lam_compile_env.primitive_description)
 
     | "caml_obj_truncate"
     | "caml_lazy_make_forward" -> 
-        E.runtime_call Js_helper.obj_runtime prim.prim_name args 
+      E.runtime_call Js_helper.obj_runtime prim.prim_name args 
 
     | "caml_format_float"
     | "caml_format_int"
@@ -526,7 +523,7 @@ let query (prim : Lam_compile_env.primitive_description)
     | "caml_int_of_string" (* what is the semantics?*)
     | "caml_int32_of_string"
     | "caml_nativeint_of_string" -> 
-        E.runtime_call Js_helper.format prim.prim_name args
+      E.runtime_call Js_helper.format prim.prim_name args
 
 
     (*   "caml_alloc_dummy"; *)
@@ -551,7 +548,7 @@ let query (prim : Lam_compile_env.primitive_description)
     | "caml_int32_bswap"
     | "caml_nativeint_bswap"
     | "caml_int64_bswap"
-        -> E.runtime_call Js_helper.prim prim.prim_name args 
+      -> E.runtime_call Js_helper.prim prim.prim_name args 
     | "caml_get_public_method"
       ->
       E.runtime_call Js_helper.oo prim.prim_name args      
@@ -597,61 +594,62 @@ let query (prim : Lam_compile_env.primitive_description)
     | "caml_ml_seek_out"
     | "caml_ml_seek_out_64"
     | "caml_ml_set_binary_mode"
-        ->  E.runtime_call Js_helper.prim prim.prim_name args 
+    | "caml_sys_getcwd" (* check browser or nodejs *)
+      ->  E.runtime_call Js_helper.prim prim.prim_name args 
 
 
     | "js_function_length"
-      
-        -> begin
+
+      -> begin
           match args with 
           | [f ] -> E.function_length f 
           | _ -> assert false
         end
     | "js_create_array" 
-        -> 
-          begin match args with 
-          | [e] -> E.uninitialized_array e 
-          | _ -> assert false
-          end
+      -> 
+      begin match args with 
+        | [e] -> E.uninitialized_array e 
+        | _ -> assert false
+      end
     | "js_array_append" 
       -> 
-        begin match args with 
+      begin match args with 
         | [a;b] -> 
-            E.array_append a b 
+          E.array_append a b 
         | _ -> assert false 
-        end
+      end
     | "js_string_append"
-        -> 
-          begin match args with 
-          | [a ; b] -> E.string_append a b 
-          | _ -> assert false
-          end
+      -> 
+      begin match args with 
+        | [a ; b] -> E.string_append a b 
+        | _ -> assert false
+      end
     | "js_apply" 
       -> 
-        begin match args with 
+      begin match args with 
         | [f ;  args] -> 
-            E.flat_call f args
+          E.flat_call f args
         | _ -> assert false 
-        end
+      end
     | "js_string_of_small_int_array"
       ->
-        begin match args with 
+      begin match args with 
         | [e] -> E.string_of_small_int_array e 
         | _ -> assert false
-        end
+      end
     | "js_typeof"
       -> 
       begin match args with 
-      | [e] -> E.typeof e         
-      | _ -> assert false
+        | [e] -> E.typeof e         
+        | _ -> assert false
       end
-      
+
     | "js_dump"
       -> 
       (* This primitive can accept any number of arguments 
          {[
            console.log(1,2,3)
-           1 2 3
+             1 2 3
          ]}         
       *)      
       E.seq (E.dump Log args) (E.unit ())
@@ -661,17 +659,17 @@ let query (prim : Lam_compile_env.primitive_description)
     | "js_anything_to_string" 
       ->
       begin match args with 
-      | [e] -> E.anything_to_string e 
-      | _ -> assert false
+        | [e] -> E.anything_to_string e 
+        | _ -> assert false
       end
-      
+
     | "js_json_stringify"      
       -> 
       begin match args with 
-      | [e] ->        
-        E.to_json_string e
-      | _ -> 
-        assert false      
+        | [e] ->        
+          E.to_json_string e
+        | _ -> 
+          assert false      
       end
     (* | "js_dump1" *)
     (* | "js_dump2" *)
@@ -690,23 +688,20 @@ let query (prim : Lam_compile_env.primitive_description)
     | "js_apply6"
     | "js_apply7"
     | "js_apply8" -> 
-        begin match args with 
+      begin match args with 
         | fn :: rest -> 
-            E.call ~info:{arity=Full} fn rest 
+          E.call ~info:{arity=Full} fn rest 
         | _ -> assert false
-        end
+      end
     | _ -> 
 
       let comment = "Missing primitve" in       
       Ext_log.warn __LOC__ "%s" (Printf.sprintf  "%s: %s\n" comment prim.prim_name) ;
-      E.str ~comment ~pure:false  prim.prim_name;
-      (* raise X.NA *) (* Fall back, maybe spit out a warning*)
-    end in 
-     v 
-  with X.NA ->
-    E.runtime_call Js_helper.prim prim.prim_name args 
-    (*TODO check arity *)
-   
+      (*we dont use [throw] here, since [throw] is an statement  *)        
+      E.dump ~comment Error [( E.str ~comment ~pure:false  prim.prim_name)];
+
+  end 
+
 
 
 ;;

--- a/jscomp/runtime/caml_primitive.js
+++ b/jscomp/runtime/caml_primitive.js
@@ -297,3 +297,8 @@ function caml_hash(count, limit, seed, o) {
     return hashCode(JSON.stringify(o));
 }
 exports.caml_hash = caml_hash;
+// TODO: Check NodeJS and browser
+function caml_sys_getcwd(unit) {
+    return "/";
+}
+exports.caml_sys_getcwd = caml_sys_getcwd;

--- a/jscomp/runtime/caml_primitive.ts
+++ b/jscomp/runtime/caml_primitive.ts
@@ -296,7 +296,13 @@ function caml_hash(count,limit, seed, o) {
 }
 
 
+// TODO: Check NodeJS and browser
+function caml_sys_getcwd(unit : number) : string  { 
+    return "/"; 
+}
+
 export {
+    caml_sys_getcwd,
     caml_update_dummy,
     caml_compare,
     caml_hash,

--- a/jscomp/test/ext_filename.js
+++ b/jscomp/test/ext_filename.js
@@ -5,6 +5,7 @@ var Filename        = require("../stdlib/filename");
 var Caml_exceptions = require("../runtime/caml_exceptions");
 var Pervasives      = require("../stdlib/pervasives");
 var Ext_string      = require("./ext_string");
+var Caml_primitive  = require("../runtime/caml_primitive");
 var $$String        = require("../stdlib/string");
 var List            = require("../stdlib/list");
 
@@ -15,7 +16,7 @@ var node_parent = "..";
 var node_current = ".";
 
 function absolute_path(s) {
-  var s$1 = Filename.is_relative(s) ? Filename.concat(/* Missing primitve */"caml_sys_getcwd", s) : s;
+  var s$1 = Filename.is_relative(s) ? Filename.concat(Caml_primitive.caml_sys_getcwd(/* () */0), s) : s;
   var aux = function (_s) {
     while(true) {
       var s = _s;

--- a/jscomp/test/test_char.d.ts
+++ b/jscomp/test/test_char.d.ts
@@ -1,6 +1,5 @@
 export var f: (x : any) => any ;
 export var chr: (n : any) => any ;
-export var escaped: (c : any) => any ;
 export var lowercase: (c : any) => any ;
 export var uppercase: (c : any) => any ;
 export var compare: (c1 : any, c2 : any) => any ;

--- a/jscomp/test/test_char.js
+++ b/jscomp/test/test_char.js
@@ -1,8 +1,7 @@
 // Generated CODE, PLEASE EDIT WITH CARE
 "use strict";
 
-var Pervasives  = require("../stdlib/pervasives");
-var Caml_string = require("../runtime/caml_string");
+var Pervasives = require("../stdlib/pervasives");
 
 function f(x) {
   return x + 1;
@@ -15,64 +14,6 @@ function chr(n) {
   else {
     return n;
   }
-}
-
-function escaped(c) {
-  var exit = 0;
-  if (c !== 39) {
-    if (c !== 92) {
-      if (c >= 14) {
-        exit = 1;
-      }
-      else {
-        switch (c) {
-          case 8 : 
-              return "\\b";
-          case 9 : 
-              return "\\t";
-          case 10 : 
-              return "\\n";
-          case 0 : 
-          case 1 : 
-          case 2 : 
-          case 3 : 
-          case 4 : 
-          case 5 : 
-          case 6 : 
-          case 7 : 
-          case 11 : 
-          case 12 : 
-              exit = 1;
-              break;
-          case 13 : 
-              return "\\r";
-          
-        }
-      }
-    }
-    else {
-      return "\\\\";
-    }
-  }
-  else {
-    return "\\'";
-  }
-  if (exit === 1) {
-    if (Caml_string.caml_is_printable(c)) {
-      var s = new Array(1);
-      /* unknown */"string.unsafe_set";
-      return s;
-    }
-    else {
-      var s$1 = new Array(4);
-      /* unknown */"string.unsafe_set";
-      /* unknown */"string.unsafe_set";
-      /* unknown */"string.unsafe_set";
-      /* unknown */"string.unsafe_set";
-      return s$1;
-    }
-  }
-  
 }
 
 function lowercase(c) {
@@ -99,7 +40,6 @@ function compare(c1, c2) {
 
 exports.f         = f;
 exports.chr       = chr;
-exports.escaped   = escaped;
 exports.lowercase = lowercase;
 exports.uppercase = uppercase;
 exports.compare   = compare;

--- a/jscomp/test/test_char.ml
+++ b/jscomp/test/test_char.ml
@@ -27,30 +27,6 @@ external string_unsafe_get : string -> int -> char = "%string_unsafe_get"
 
 
 (** this primitive -- should be removed ..  *)
-external string_unsafe_set : string -> int -> char -> unit
-                           = "%string_unsafe_set"
-
-let escaped = function
-  | '\'' -> "\\'"
-  | '\\' -> "\\\\"
-  | '\n' -> "\\n"
-  | '\t' -> "\\t"
-  | '\r' -> "\\r"
-  | '\b' -> "\\b"
-  | c ->
-    if is_printable c then begin
-      let s = string_create 1 in
-      string_unsafe_set s 0 c;
-      s
-    end else begin
-      let n = code c in
-      let s = string_create 4 in
-      string_unsafe_set s 0 '\\';
-      string_unsafe_set s 1 (unsafe_chr (48 + n / 100));
-      string_unsafe_set s 2 (unsafe_chr (48 + (n / 10) mod 10));
-      string_unsafe_set s 3 (unsafe_chr (48 + n mod 10));
-      s
-    end
 
 let lowercase c =
   if (c >= 'A' && c <= 'Z')

--- a/jscomp/test/test_fastdt.js
+++ b/jscomp/test/test_fastdt.js
@@ -236,8 +236,8 @@ function find_split_feature(c_t, c_f, _F, _Y, _W, used, validEx) {
     if (!Hashtbl.mem(used, f)) {
       var c_1t = 0;
       var c_1f = 0;
-      for(var i = 0 ,i_finish = /* unknown */"Bigarray.dim_1" - 1; i<= i_finish; ++i){
-        var n = /* unknown */"Bigarray.get[generic,unknown]";
+      for(var i = 0 ,i_finish = console.error("Missing primitve: Bigarray.dim_1\n") - 1; i<= i_finish; ++i){
+        var n = console.error("Missing primitve: Bigarray.get[generic,unknown]\n");
         if (validEx[n] > 0) {
           if (_Y[n]) {
             c_1t += _W[n];
@@ -440,19 +440,19 @@ function build_dt(max_depth, leaf_acc, smooth, validExO, _F, _Y, _W) {
         var f = match$1[3];
         var match$2 = match$1[2];
         Hashtbl.replace(used, f, /* () */0);
-        for(var m = 0 ,m_finish = /* unknown */"Bigarray.dim_1" - 1; m<= m_finish; ++m){
-          validEx[/* unknown */"Bigarray.get[camlint,C]"] = validEx[/* unknown */"Bigarray.get[camlint,C]"] - 1;
+        for(var m = 0 ,m_finish = console.error("Missing primitve: Bigarray.dim_1\n") - 1; m<= m_finish; ++m){
+          validEx[console.error("Missing primitve: Bigarray.get[camlint,C]\n")] = validEx[console.error("Missing primitve: Bigarray.get[camlint,C]\n")] - 1;
         }
         var r = build_dt$prime(depth + 1, match$2[1], match$2[2]);
-        for(var m$1 = 0 ,m_finish$1 = /* unknown */"Bigarray.dim_1" - 1; m$1<= m_finish$1; ++m$1){
-          validEx[/* unknown */"Bigarray.get[camlint,C]"] = validEx[/* unknown */"Bigarray.get[camlint,C]"] + 2;
+        for(var m$1 = 0 ,m_finish$1 = console.error("Missing primitve: Bigarray.dim_1\n") - 1; m$1<= m_finish$1; ++m$1){
+          validEx[console.error("Missing primitve: Bigarray.get[camlint,C]\n")] = validEx[console.error("Missing primitve: Bigarray.get[camlint,C]\n")] + 2;
         }
         for(var n = 0 ,n_finish = _N - 1; n<= n_finish; ++n){
           validEx[n] = validEx[n] - 1;
         }
         var l = build_dt$prime(depth + 1, match$2[3], match$2[4]);
-        for(var m$2 = 0 ,m_finish$2 = /* unknown */"Bigarray.dim_1" - 1; m$2<= m_finish$2; ++m$2){
-          validEx[/* unknown */"Bigarray.get[camlint,C]"] = validEx[/* unknown */"Bigarray.get[camlint,C]"] - 1;
+        for(var m$2 = 0 ,m_finish$2 = console.error("Missing primitve: Bigarray.dim_1\n") - 1; m$2<= m_finish$2; ++m$2){
+          validEx[console.error("Missing primitve: Bigarray.get[camlint,C]\n")] = validEx[console.error("Missing primitve: Bigarray.get[camlint,C]\n")] - 1;
         }
         for(var n$1 = 0 ,n_finish$1 = _N - 1; n$1<= n_finish$1; ++n$1){
           validEx[n$1] = validEx[n$1] + 1;


### PR DESCRIPTION
and also warning in the compile time, also it will return undefined