### PR TITLE
fix && || tail call, it generates some large expressions (Fix #50)

### DIFF
--- a/jscomp/js_output.ml
+++ b/jscomp/js_output.ml
@@ -48,7 +48,9 @@ let of_block ?value ?(finished = False) block =
 
 let dummy = {value = None; block = []; finished = Dummy }
 
-let handle_name_tail (name : st) (should_return : Lam_compile_defs.return_type)
+let handle_name_tail 
+    (name : st)
+    (should_return : Lam_compile_defs.return_type)
     lam (exp : J.expression) : t =
   begin match name, should_return with 
   | EffectCall, False -> 
@@ -66,10 +68,13 @@ let handle_name_tail (name : st) (should_return : Lam_compile_defs.return_type)
   | NeedValue, _ -> {block = []; value = Some exp; finished = False }
   end
 
-let handle_block_return (st : st) (should_return : Lam_compile_defs.return_type) (lam : Lambda.lambda) (block : J.block) exp : t = 
+let handle_block_return 
+    (st : st) 
+    (should_return : Lam_compile_defs.return_type)
+    (lam : Lambda.lambda) (block : J.block) exp : t = 
   match st, should_return with 
   | Declare (kind,n), False -> 
-      make (block @ [ S.define ~kind  n exp])
+    make (block @ [ S.define ~kind  n exp])
   | Assign n, False -> make (block @ [S.assign n exp])
   | (Declare _ | Assign _), True _ -> make [S.unknown_lambda lam] ~finished:True
   | EffectCall, False -> make block ~value:exp

--- a/jscomp/lam_analysis.ml
+++ b/jscomp/lam_analysis.ml
@@ -454,3 +454,4 @@ let is_closed_by set lam =
 
 let is_closed  lam = 
   Ident_map.is_empty (free_variables Ident_set.empty Ident_map.empty lam)  
+

--- a/jscomp/lam_analysis.mli
+++ b/jscomp/lam_analysis.mli
@@ -61,3 +61,5 @@ val free_variables : Ident_set.t -> stats Ident_map.t -> Lambda.lambda -> stats 
 
 val small_inline_size : int 
 val exit_inline_size : int 
+
+

--- a/jscomp/lam_util.ml
+++ b/jscomp/lam_util.ml
@@ -311,3 +311,8 @@ let print_ident_set fmt s =
 
 let mk_apply_info ?(loc = Location.none)  apply_status : Lambda.apply_info =
   { apply_loc = loc; apply_status }
+
+
+let lam_true : Lambda.lambda = Lconst (Const_pointer ( 1, NullConstructor "true")) 
+
+let lam_false : Lambda.lambda = Lconst (Const_pointer( 0, NullConstructor "false"))

--- a/jscomp/lam_util.mli
+++ b/jscomp/lam_util.mli
@@ -58,3 +58,6 @@ val ident_set_of_list : Ident.t list -> Ident_set.t
 val print_ident_set : Format.formatter -> Ident_set.t -> unit
 
 val mk_apply_info : ?loc:Location.t -> Lambda.apply_status -> Lambda.apply_info
+
+val lam_true : Lambda.lambda
+val lam_false : Lambda.lambda

--- a/jscomp/runtime/caml_string.js
+++ b/jscomp/runtime/caml_string.js
@@ -149,7 +149,12 @@ function caml_string_of_char_array(chars) {
 
 function caml_is_printable(c) {
   var code = c;
-  return +(code > 31 && code < 127);
+  if (code > 31) {
+    return +(code < 127);
+  }
+  else {
+    return /* false */0;
+  }
 }
 
 exports.add                       = add;

--- a/jscomp/stdlib/camlinternalFormat.js
+++ b/jscomp/stdlib/camlinternalFormat.js
@@ -339,7 +339,12 @@ function bprint_char_set(buf, char_set) {
     var is_alone = function (c) {
       var match_001 = Char.chr(c - 1);
       var match_002 = Char.chr(c + 1);
-      return +(is_in_char_set(set, c) && !(is_in_char_set(set, match_001) && is_in_char_set(set, match_002)));
+      if (is_in_char_set(set, c)) {
+        return !(is_in_char_set(set, match_001) && is_in_char_set(set, match_002));
+      }
+      else {
+        return /* false */0;
+      }
     };
     if (is_alone(/* "]" */93)) {
       buffer_add_char(buf, /* "]" */93);

--- a/jscomp/stdlib/filename.js
+++ b/jscomp/stdlib/filename.js
@@ -98,15 +98,35 @@ function is_dir_sep(s, i) {
 }
 
 function is_relative(n) {
-  return +(n.length < 1 || n.charCodeAt(0) !== /* "/" */47);
+  if (n.length < 1) {
+    return /* true */1;
+  }
+  else {
+    return +(n.charCodeAt(0) !== /* "/" */47);
+  }
 }
 
 function is_implicit(n) {
-  return +(is_relative(n) && (n.length < 2 || $$String.sub(n, 0, 2) !== "./") && (n.length < 3 || $$String.sub(n, 0, 3) !== "../"));
+  if (is_relative(n) && (n.length < 2 || $$String.sub(n, 0, 2) !== "./")) {
+    if (n.length < 3) {
+      return /* true */1;
+    }
+    else {
+      return +($$String.sub(n, 0, 3) !== "../");
+    }
+  }
+  else {
+    return /* false */0;
+  }
 }
 
 function check_suffix(name, suff) {
-  return +(name.length >= suff.length && $$String.sub(name, name.length - suff.length, suff.length) === suff);
+  if (name.length >= suff.length) {
+    return +($$String.sub(name, name.length - suff.length, suff.length) === suff);
+  }
+  else {
+    return /* false */0;
+  }
 }
 
 var temp_dir_name;

--- a/jscomp/stdlib/hashtbl.js
+++ b/jscomp/stdlib/hashtbl.js
@@ -361,15 +361,21 @@ function replace(h, key, info) {
 }
 
 function mem(h, key) {
-  var mem_in_bucket = function (param) {
+  var _param = h[2][key_index(h, key)];
+  while(true) {
+    var param = _param;
     if (param) {
-      return +(Caml_primitive.caml_compare(param[1], key) === 0 || mem_in_bucket(param[3]));
+      if (Caml_primitive.caml_compare(param[1], key)) {
+        _param = param[3];
+      }
+      else {
+        return /* true */1;
+      }
     }
     else {
       return /* false */0;
     }
   };
-  return mem_in_bucket(h[2][key_index(h, key)]);
 }
 
 function iter(f, h) {
@@ -620,15 +626,21 @@ function MakeSeeded(H) {
     }
   };
   var mem = function (h, key) {
-    var mem_in_bucket = function (param) {
+    var _param = h[2][key_index(h, key)];
+    while(true) {
+      var param = _param;
       if (param) {
-        return +(H[1](param[1], key) || mem_in_bucket(param[3]));
+        if (H[1](param[1], key)) {
+          return /* true */1;
+        }
+        else {
+          _param = param[3];
+        }
       }
       else {
         return /* false */0;
       }
     };
-    return mem_in_bucket(h[2][key_index(h, key)]);
   };
   return [
           0,
@@ -823,15 +835,21 @@ function Make(H) {
     }
   };
   var mem = function (h, key) {
-    var mem_in_bucket = function (param) {
+    var _param = h[2][key_index(h, key)];
+    while(true) {
+      var param = _param;
       if (param) {
-        return +(equal(param[1], key) || mem_in_bucket(param[3]));
+        if (equal(param[1], key)) {
+          return /* true */1;
+        }
+        else {
+          _param = param[3];
+        }
       }
       else {
         return /* false */0;
       }
     };
-    return mem_in_bucket(h[2][key_index(h, key)]);
   };
   var create$1 = function (sz) {
     return create([

--- a/jscomp/stdlib/list.js
+++ b/jscomp/stdlib/list.js
@@ -319,74 +319,126 @@ function fold_right2(f, l1, l2, accu) {
   }
 }
 
-function for_all(p, param) {
-  if (param) {
-    return +(p(param[1]) && for_all(p, param[2]));
-  }
-  else {
-    return /* true */1;
-  }
-}
-
-function exists(p, param) {
-  if (param) {
-    return +(p(param[1]) || exists(p, param[2]));
-  }
-  else {
-    return /* false */0;
-  }
-}
-
-function for_all2(p, l1, l2) {
-  if (l1) {
-    if (l2) {
-      return +(p(l1[1], l2[1]) && for_all2(p, l1[2], l2[2]));
+function for_all(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[1])) {
+        _param = param[2];
+      }
+      else {
+        return /* false */0;
+      }
     }
     else {
+      return /* true */1;
+    }
+  };
+}
+
+function exists(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[1])) {
+        return /* true */1;
+      }
+      else {
+        _param = param[2];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
+}
+
+function for_all2(p, _l1, _l2) {
+  while(true) {
+    var l2 = _l2;
+    var l1 = _l1;
+    if (l1) {
+      if (l2) {
+        if (p(l1[1], l2[1])) {
+          _l2 = l2[2];
+          _l1 = l1[2];
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return Pervasives.invalid_arg("List.for_all2");
+      }
+    }
+    else if (l2) {
       return Pervasives.invalid_arg("List.for_all2");
     }
-  }
-  else if (l2) {
-    return Pervasives.invalid_arg("List.for_all2");
-  }
-  else {
-    return /* true */1;
-  }
+    else {
+      return /* true */1;
+    }
+  };
 }
 
-function exists2(p, l1, l2) {
-  if (l1) {
-    if (l2) {
-      return +(p(l1[1], l2[1]) || exists2(p, l1[2], l2[2]));
+function exists2(p, _l1, _l2) {
+  while(true) {
+    var l2 = _l2;
+    var l1 = _l1;
+    if (l1) {
+      if (l2) {
+        if (p(l1[1], l2[1])) {
+          return /* true */1;
+        }
+        else {
+          _l2 = l2[2];
+          _l1 = l1[2];
+        }
+      }
+      else {
+        return Pervasives.invalid_arg("List.exists2");
+      }
     }
-    else {
+    else if (l2) {
       return Pervasives.invalid_arg("List.exists2");
     }
-  }
-  else if (l2) {
-    return Pervasives.invalid_arg("List.exists2");
-  }
-  else {
-    return /* false */0;
-  }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
-function mem(x, param) {
-  if (param) {
-    return +(Caml_primitive.caml_compare(param[1], x) === 0 || mem(x, param[2]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (Caml_primitive.caml_compare(param[1], x)) {
+        _param = param[2];
+      }
+      else {
+        return /* true */1;
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
-function memq(x, param) {
-  if (param) {
-    return +(param[1] === x || memq(x, param[2]));
-  }
-  else {
-    return /* false */0;
-  }
+function memq(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (param[1] === x) {
+        return /* true */1;
+      }
+      else {
+        _param = param[2];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function assoc(x, _param) {
@@ -425,22 +477,38 @@ function assq(x, _param) {
   };
 }
 
-function mem_assoc(x, param) {
-  if (param) {
-    return +(Caml_primitive.caml_compare(param[1][1], x) === 0 || mem_assoc(x, param[2]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem_assoc(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (Caml_primitive.caml_compare(param[1][1], x)) {
+        _param = param[2];
+      }
+      else {
+        return /* true */1;
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
-function mem_assq(x, param) {
-  if (param) {
-    return +(param[1][1] === x || mem_assq(x, param[2]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem_assq(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (param[1][1] === x) {
+        return /* true */1;
+      }
+      else {
+        _param = param[2];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function remove_assoc(x, param) {

--- a/jscomp/stdlib/map.js
+++ b/jscomp/stdlib/map.js
@@ -151,14 +151,22 @@ function Make(funarg) {
       }
     };
   };
-  var mem = function (x, param) {
-    if (param) {
-      var c = funarg[1](x, param[2]);
-      return +(c === 0 || mem(x, c < 0 ? param[1] : param[4]));
-    }
-    else {
-      return /* false */0;
-    }
+  var mem = function (x, _param) {
+    while(true) {
+      var param = _param;
+      if (param) {
+        var c = funarg[1](x, param[2]);
+        if (c) {
+          _param = c < 0 ? param[1] : param[4];
+        }
+        else {
+          return /* true */1;
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    };
   };
   var min_binding = function (_param) {
     while(true) {
@@ -315,21 +323,45 @@ function Make(funarg) {
       }
     };
   };
-  var for_all = function (p, param) {
-    if (param) {
-      return +(p(param[2], param[3]) && for_all(p, param[1]) && for_all(p, param[4]));
-    }
-    else {
-      return /* true */1;
-    }
+  var for_all = function (p, _param) {
+    while(true) {
+      var param = _param;
+      if (param) {
+        if (p(param[2], param[3])) {
+          if (for_all(p, param[1])) {
+            _param = param[4];
+          }
+          else {
+            return /* false */0;
+          }
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return /* true */1;
+      }
+    };
   };
-  var exists = function (p, param) {
-    if (param) {
-      return +(p(param[2], param[3]) || exists(p, param[1]) || exists(p, param[4]));
-    }
-    else {
-      return /* false */0;
-    }
+  var exists = function (p, _param) {
+    while(true) {
+      var param = _param;
+      if (param) {
+        if (p(param[2], param[3])) {
+          return /* true */1;
+        }
+        else if (exists(p, param[1])) {
+          return /* true */1;
+        }
+        else {
+          _param = param[4];
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    };
   };
   var add_min_binding = function (k, v, param) {
     if (param) {
@@ -592,10 +624,23 @@ function Make(funarg) {
     };
   };
   var equal = function (cmp, m1, m2) {
-    var equal_aux = function (e1, e2) {
+    var _e1 = cons_enum(m1, /* End */0);
+    var _e2 = cons_enum(m2, /* End */0);
+    while(true) {
+      var e2 = _e2;
+      var e1 = _e1;
       if (e1) {
         if (e2) {
-          return +(funarg[1](e1[1], e2[1]) === 0 && cmp(e1[2], e2[2]) && equal_aux(cons_enum(e1[3], e1[4]), cons_enum(e2[3], e2[4])));
+          if (funarg[1](e1[1], e2[1])) {
+            return /* false */0;
+          }
+          else if (cmp(e1[2], e2[2])) {
+            _e2 = cons_enum(e2[3], e2[4]);
+            _e1 = cons_enum(e1[3], e1[4]);
+          }
+          else {
+            return /* false */0;
+          }
         }
         else {
           return /* false */0;
@@ -608,7 +653,6 @@ function Make(funarg) {
         return /* true */1;
       }
     };
-    return equal_aux(cons_enum(m1, /* End */0), cons_enum(m2, /* End */0));
   };
   var cardinal = function (param) {
     if (param) {

--- a/jscomp/stdlib/printexc.js
+++ b/jscomp/stdlib/printexc.js
@@ -509,13 +509,21 @@ function backtrace_slots(raw_backtrace) {
         return /* true */1;
       }
     };
-    var exists_usable = function (i) {
-      if (i !== -1) {
-        return +(usable_slot(backtrace[i]) || exists_usable(i - 1));
-      }
-      else {
-        return /* false */0;
-      }
+    var exists_usable = function (_i) {
+      while(true) {
+        var i = _i;
+        if (i !== -1) {
+          if (usable_slot(backtrace[i])) {
+            return /* true */1;
+          }
+          else {
+            _i = i - 1;
+          }
+        }
+        else {
+          return /* false */0;
+        }
+      };
     };
     if (exists_usable(backtrace.length - 1)) {
       return [

--- a/jscomp/stdlib/set.js
+++ b/jscomp/stdlib/set.js
@@ -266,14 +266,22 @@ function Make(funarg) {
       return /* true */1;
     }
   };
-  var mem = function (x, param) {
-    if (param) {
-      var c = funarg[1](x, param[2]);
-      return +(c === 0 || mem(x, c < 0 ? param[1] : param[3]));
-    }
-    else {
-      return /* false */0;
-    }
+  var mem = function (x, _param) {
+    while(true) {
+      var param = _param;
+      if (param) {
+        var c = funarg[1](x, param[2]);
+        if (c) {
+          _param = c < 0 ? param[1] : param[3];
+        }
+        else {
+          return /* true */1;
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    };
   };
   var remove = function (x, param) {
     if (param) {
@@ -437,46 +445,62 @@ function Make(funarg) {
   var equal = function (s1, s2) {
     return +(compare(s1, s2) === 0);
   };
-  var subset = function (s1, s2) {
-    if (s1) {
-      if (s2) {
-        var r2 = s2[3];
-        var l2 = s2[1];
-        var r1 = s1[3];
-        var v1 = s1[2];
-        var l1 = s1[1];
-        var c = funarg[1](v1, s2[2]);
-        if (c) {
-          if (c < 0) {
-            return +(subset([
-                          /* Node */0,
-                          l1,
-                          v1,
-                          /* Empty */0,
-                          0
-                        ], l2) && subset(r1, s2));
+  var subset = function (_s1, _s2) {
+    while(true) {
+      var s2 = _s2;
+      var s1 = _s1;
+      if (s1) {
+        if (s2) {
+          var r2 = s2[3];
+          var l2 = s2[1];
+          var r1 = s1[3];
+          var v1 = s1[2];
+          var l1 = s1[1];
+          var c = funarg[1](v1, s2[2]);
+          if (c) {
+            if (c < 0) {
+              if (subset([
+                      /* Node */0,
+                      l1,
+                      v1,
+                      /* Empty */0,
+                      0
+                    ], l2)) {
+                _s1 = r1;
+              }
+              else {
+                return /* false */0;
+              }
+            }
+            else if (subset([
+                    /* Node */0,
+                    /* Empty */0,
+                    v1,
+                    r1,
+                    0
+                  ], r2)) {
+              _s1 = l1;
+            }
+            else {
+              return /* false */0;
+            }
+          }
+          else if (subset(l1, l2)) {
+            _s2 = r2;
+            _s1 = r1;
           }
           else {
-            return +(subset([
-                          /* Node */0,
-                          /* Empty */0,
-                          v1,
-                          r1,
-                          0
-                        ], r2) && subset(l1, s2));
+            return /* false */0;
           }
         }
         else {
-          return +(subset(l1, l2) && subset(r1, r2));
+          return /* false */0;
         }
       }
       else {
-        return /* false */0;
+        return /* true */1;
       }
-    }
-    else {
-      return /* true */1;
-    }
+    };
   };
   var iter = function (f, _param) {
     while(true) {
@@ -504,21 +528,45 @@ function Make(funarg) {
       }
     };
   };
-  var for_all = function (p, param) {
-    if (param) {
-      return +(p(param[2]) && for_all(p, param[1]) && for_all(p, param[3]));
-    }
-    else {
-      return /* true */1;
-    }
+  var for_all = function (p, _param) {
+    while(true) {
+      var param = _param;
+      if (param) {
+        if (p(param[2])) {
+          if (for_all(p, param[1])) {
+            _param = param[3];
+          }
+          else {
+            return /* false */0;
+          }
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return /* true */1;
+      }
+    };
   };
-  var exists = function (p, param) {
-    if (param) {
-      return +(p(param[2]) || exists(p, param[1]) || exists(p, param[3]));
-    }
-    else {
-      return /* false */0;
-    }
+  var exists = function (p, _param) {
+    while(true) {
+      var param = _param;
+      if (param) {
+        if (p(param[2])) {
+          return /* true */1;
+        }
+        else if (exists(p, param[1])) {
+          return /* true */1;
+        }
+        else {
+          _param = param[3];
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    };
   };
   var filter = function (p, param) {
     if (param) {

--- a/jscomp/test/a_string_test.js
+++ b/jscomp/test/a_string_test.js
@@ -98,7 +98,12 @@ var suites_002 = [
             return Mt.assert_equal(List.filter(function (s) {
                               return +(s !== "");
                             })(split_by(/* None */0, function (x) {
-                                return +(x === /* " " */32 || x === /* "\t" */9);
+                                if (x === /* " " */32) {
+                                  return /* true */1;
+                                }
+                                else {
+                                  return +(x === /* "\t" */9);
+                                }
                               }, "h hgso hgso \t hi")), [
                         /* :: */0,
                         "h",

--- a/jscomp/test/ext_string.js
+++ b/jscomp/test/ext_string.js
@@ -55,11 +55,16 @@ function split(keep_empty, str, on) {
 function starts_with(s, beg) {
   var beg_len = beg.length;
   var s_len = s.length;
-  var i = 0;
-  while(i < beg_len && s[i] === beg[i]) {
-    ++ i;
-  };
-  return +(beg_len <= s_len && i === beg_len);
+  if (beg_len <= s_len) {
+    var i = 0;
+    while(i < beg_len && s[i] === beg[i]) {
+      ++ i;
+    };
+    return +(i === beg_len);
+  }
+  else {
+    return /* false */0;
+  }
 }
 
 function ends_with(s, beg) {
@@ -135,15 +140,19 @@ function escaped(s) {
 
 function for_all(p, s) {
   var len = s.length;
-  var aux = function (i) {
+  var _i = 0;
+  while(true) {
+    var i = _i;
     if (i >= len) {
       return /* true */1;
     }
+    else if (p(s.charCodeAt(i))) {
+      _i = i + 1;
+    }
     else {
-      return +(p(s.charCodeAt(i)) && aux(i + 1));
+      return /* false */0;
     }
   };
-  return aux(0);
 }
 
 function is_empty(s) {

--- a/jscomp/test/int_map.js
+++ b/jscomp/test/int_map.js
@@ -158,14 +158,22 @@ function find(x, _param) {
   };
 }
 
-function mem(x, param) {
-  if (param) {
-    var c = Caml_primitive.caml_int_compare(x, param[2]);
-    return +(c === 0 || mem(x, c < 0 ? param[1] : param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      var c = Caml_primitive.caml_int_compare(x, param[2]);
+      if (c) {
+        _param = c < 0 ? param[1] : param[4];
+      }
+      else {
+        return /* true */1;
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function min_binding(_param) {
@@ -331,22 +339,46 @@ function fold(f, _m, _accu) {
   };
 }
 
-function for_all(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) && for_all(p, param[1]) && for_all(p, param[4]));
-  }
-  else {
-    return /* true */1;
-  }
+function for_all(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        if (for_all(p, param[1])) {
+          _param = param[4];
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    }
+    else {
+      return /* true */1;
+    }
+  };
 }
 
-function exists(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) || exists(p, param[1]) || exists(p, param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function exists(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        return /* true */1;
+      }
+      else if (exists(p, param[1])) {
+        return /* true */1;
+      }
+      else {
+        _param = param[4];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function add_min_binding(k, v, param) {
@@ -621,10 +653,25 @@ function compare(cmp, m1, m2) {
 }
 
 function equal(cmp, m1, m2) {
-  var equal_aux = function (e1, e2) {
+  var _e1 = cons_enum(m1, /* End */0);
+  var _e2 = cons_enum(m2, /* End */0);
+  while(true) {
+    var e2 = _e2;
+    var e1 = _e1;
     if (e1) {
       if (e2) {
-        return +(e1[1] === e2[1] && cmp(e1[2], e2[2]) && equal_aux(cons_enum(e1[3], e1[4]), cons_enum(e2[3], e2[4])));
+        if (e1[1] === e2[1]) {
+          if (cmp(e1[2], e2[2])) {
+            _e2 = cons_enum(e2[3], e2[4]);
+            _e1 = cons_enum(e1[3], e1[4]);
+          }
+          else {
+            return /* false */0;
+          }
+        }
+        else {
+          return /* false */0;
+        }
       }
       else {
         return /* false */0;
@@ -637,7 +684,6 @@ function equal(cmp, m1, m2) {
       return /* true */1;
     }
   };
-  return equal_aux(cons_enum(m1, /* End */0), cons_enum(m2, /* End */0));
 }
 
 function cardinal(param) {

--- a/jscomp/test/map_test.js
+++ b/jscomp/test/map_test.js
@@ -182,6 +182,40 @@ function compare(cmp, m1, m2) {
   };
 }
 
+function equal(cmp, m1, m2) {
+  var _e1 = cons_enum(m1, /* End */0);
+  var _e2 = cons_enum(m2, /* End */0);
+  while(true) {
+    var e2 = _e2;
+    var e1 = _e1;
+    if (e1) {
+      if (e2) {
+        if (e1[1] === e2[1]) {
+          if (cmp(e1[2], e2[2])) {
+            _e2 = cons_enum(e2[3], e2[4]);
+            _e1 = cons_enum(e1[3], e1[4]);
+          }
+          else {
+            return /* false */0;
+          }
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    }
+    else if (e2) {
+      return /* false */0;
+    }
+    else {
+      return /* true */1;
+    }
+  };
+}
+
 function cardinal(param) {
   if (param) {
     return cardinal(param[1]) + 1 + cardinal(param[4]);
@@ -456,48 +490,124 @@ var int_map_suites_002 = [
     /* :: */0,
     [
       /* tuple */0,
-      "test_inline_map",
-      Test_inline_map.assertions
+      "equal2",
+      function () {
+        var v = of_list([
+              /* :: */0,
+              [
+                /* tuple */0,
+                1,
+                /* "1" */49
+              ],
+              [
+                /* :: */0,
+                [
+                  /* tuple */0,
+                  2,
+                  /* "3" */51
+                ],
+                [
+                  /* :: */0,
+                  [
+                    /* tuple */0,
+                    3,
+                    /* "4" */52
+                  ],
+                  /* [] */0
+                ]
+              ]
+            ]);
+        var u = of_list([
+              /* :: */0,
+              [
+                /* tuple */0,
+                2,
+                /* "3" */51
+              ],
+              [
+                /* :: */0,
+                [
+                  /* tuple */0,
+                  3,
+                  /* "4" */52
+                ],
+                [
+                  /* :: */0,
+                  [
+                    /* tuple */0,
+                    1,
+                    /* "1" */49
+                  ],
+                  /* [] */0
+                ]
+              ]
+            ]);
+        if (equal(function (x, y) {
+                return +(x === y);
+              }, u, v)) {
+          return 0;
+        }
+        else {
+          throw [
+                0,
+                Caml_exceptions.Assert_failure,
+                [
+                  0,
+                  "map_test.ml",
+                  26,
+                  4
+                ]
+              ];
+        }
+      }
     ],
     [
       /* :: */0,
       [
         /* tuple */0,
-        "test_inline_map2",
-        Test_inline_map2.assertions1
+        "test_inline_map",
+        Test_inline_map.assertions
       ],
       [
         /* :: */0,
         [
           /* tuple */0,
-          "test_inline_map2_1",
-          Test_inline_map2.assertions2
+          "test_inline_map2",
+          Test_inline_map2.assertions1
         ],
         [
           /* :: */0,
           [
             /* tuple */0,
-            "test_map_find",
-            Test_map_find.assert_test
+            "test_inline_map2_1",
+            Test_inline_map2.assertions2
           ],
           [
             /* :: */0,
             [
               /* tuple */0,
-              "iteration",
-              function () {
-                var m = /* Empty */0;
-                var count = 10000;
-                for(var i = 0; i<= count; ++i){
-                  m = add$1("" + i, "" + i, m);
-                }
-                for(var i$1 = 0; i$1<= count; ++i$1){
-                  Mt.assert_equal(find("" + i$1, m), "" + i$1);
-                }
-                return /* () */0;
-              }
+              "test_map_find",
+              Test_map_find.assert_test
             ],
-            /* [] */0
+            [
+              /* :: */0,
+              [
+                /* tuple */0,
+                "iteration",
+                function () {
+                  var m = /* Empty */0;
+                  var count = 10000;
+                  for(var i = 0; i<= count; ++i){
+                    m = add$1("" + i, "" + i, m);
+                  }
+                  for(var i$1 = 0; i$1<= count; ++i$1){
+                    Mt.assert_equal(find("" + i$1, m), "" + i$1);
+                  }
+                  return /* () */0;
+                }
+              ],
+              /* [] */0
+            ]
           ]
         ]
       ]

--- a/jscomp/test/map_test.ml
+++ b/jscomp/test/map_test.ml
@@ -20,6 +20,11 @@ let int_map_suites = Int_map.[
     let u = of_list [ 2,'3';3,'4'; 1,'1'] in
     assert (compare Pervasives.compare u v = 0)
            );
+  "equal2", (fun _ -> 
+    let v = of_list [ 1,'1';2,'3';3,'4'] in
+    let u = of_list [ 2,'3';3,'4'; 1,'1'] in
+    assert (equal (fun x y -> x = y) u v     )
+    );
   "test_inline_map", Test_inline_map.assertions;
   "test_inline_map2", Test_inline_map2.assertions1; 
   "test_inline_map2_1", Test_inline_map2.assertions2; 

--- a/jscomp/test/test_for_map.js
+++ b/jscomp/test/test_for_map.js
@@ -158,14 +158,22 @@ function find(x, _param) {
   };
 }
 
-function mem(x, param) {
-  if (param) {
-    var c = Caml_primitive.caml_int_compare(x, param[2]);
-    return +(c === 0 || mem(x, c < 0 ? param[1] : param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      var c = Caml_primitive.caml_int_compare(x, param[2]);
+      if (c) {
+        _param = c < 0 ? param[1] : param[4];
+      }
+      else {
+        return /* true */1;
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function min_binding(_param) {
@@ -331,22 +339,46 @@ function fold(f, _m, _accu) {
   };
 }
 
-function for_all(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) && for_all(p, param[1]) && for_all(p, param[4]));
-  }
-  else {
-    return /* true */1;
-  }
+function for_all(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        if (for_all(p, param[1])) {
+          _param = param[4];
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    }
+    else {
+      return /* true */1;
+    }
+  };
 }
 
-function exists(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) || exists(p, param[1]) || exists(p, param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function exists(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        return /* true */1;
+      }
+      else if (exists(p, param[1])) {
+        return /* true */1;
+      }
+      else {
+        _param = param[4];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function add_min_binding(k, v, param) {
@@ -621,10 +653,25 @@ function compare(cmp, m1, m2) {
 }
 
 function equal(cmp, m1, m2) {
-  var equal_aux = function (e1, e2) {
+  var _e1 = cons_enum(m1, /* End */0);
+  var _e2 = cons_enum(m2, /* End */0);
+  while(true) {
+    var e2 = _e2;
+    var e1 = _e1;
     if (e1) {
       if (e2) {
-        return +(e1[1] === e2[1] && cmp(e1[2], e2[2]) && equal_aux(cons_enum(e1[3], e1[4]), cons_enum(e2[3], e2[4])));
+        if (e1[1] === e2[1]) {
+          if (cmp(e1[2], e2[2])) {
+            _e2 = cons_enum(e2[3], e2[4]);
+            _e1 = cons_enum(e1[3], e1[4]);
+          }
+          else {
+            return /* false */0;
+          }
+        }
+        else {
+          return /* false */0;
+        }
       }
       else {
         return /* false */0;
@@ -637,7 +684,6 @@ function equal(cmp, m1, m2) {
       return /* true */1;
     }
   };
-  return equal_aux(cons_enum(m1, /* End */0), cons_enum(m2, /* End */0));
 }
 
 function cardinal(param) {

--- a/jscomp/test/test_internalOO.js
+++ b/jscomp/test/test_internalOO.js
@@ -199,14 +199,22 @@ function find(x, _param) {
   };
 }
 
-function mem(x, param) {
-  if (param) {
-    var c = Caml_string.caml_string_compare(x, param[2]);
-    return +(c === 0 || mem(x, c < 0 ? param[1] : param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      var c = Caml_string.caml_string_compare(x, param[2]);
+      if (c) {
+        _param = c < 0 ? param[1] : param[4];
+      }
+      else {
+        return /* true */1;
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function min_binding(_param) {
@@ -372,22 +380,46 @@ function fold(f, _m, _accu) {
   };
 }
 
-function for_all(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) && for_all(p, param[1]) && for_all(p, param[4]));
-  }
-  else {
-    return /* true */1;
-  }
+function for_all(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        if (for_all(p, param[1])) {
+          _param = param[4];
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    }
+    else {
+      return /* true */1;
+    }
+  };
 }
 
-function exists(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) || exists(p, param[1]) || exists(p, param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function exists(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        return /* true */1;
+      }
+      else if (exists(p, param[1])) {
+        return /* true */1;
+      }
+      else {
+        _param = param[4];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function add_min_binding(k, v, param) {
@@ -662,10 +694,23 @@ function compare(cmp, m1, m2) {
 }
 
 function equal(cmp, m1, m2) {
-  var equal_aux = function (e1, e2) {
+  var _e1 = cons_enum(m1, /* End */0);
+  var _e2 = cons_enum(m2, /* End */0);
+  while(true) {
+    var e2 = _e2;
+    var e1 = _e1;
     if (e1) {
       if (e2) {
-        return +(Caml_string.caml_string_compare(e1[1], e2[1]) === 0 && cmp(e1[2], e2[2]) && equal_aux(cons_enum(e1[3], e1[4]), cons_enum(e2[3], e2[4])));
+        if (Caml_string.caml_string_compare(e1[1], e2[1])) {
+          return /* false */0;
+        }
+        else if (cmp(e1[2], e2[2])) {
+          _e2 = cons_enum(e2[3], e2[4]);
+          _e1 = cons_enum(e1[3], e1[4]);
+        }
+        else {
+          return /* false */0;
+        }
       }
       else {
         return /* false */0;
@@ -678,7 +723,6 @@ function equal(cmp, m1, m2) {
       return /* true */1;
     }
   };
-  return equal_aux(cons_enum(m1, /* End */0), cons_enum(m2, /* End */0));
 }
 
 function cardinal(param) {
@@ -897,14 +941,22 @@ function find$1(x, _param) {
   };
 }
 
-function mem$1(x, param) {
-  if (param) {
-    var c = Caml_string.caml_string_compare(x, param[2]);
-    return +(c === 0 || mem$1(x, c < 0 ? param[1] : param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem$1(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      var c = Caml_string.caml_string_compare(x, param[2]);
+      if (c) {
+        _param = c < 0 ? param[1] : param[4];
+      }
+      else {
+        return /* true */1;
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function min_binding$1(_param) {
@@ -1070,22 +1122,46 @@ function fold$1(f, _m, _accu) {
   };
 }
 
-function for_all$1(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) && for_all$1(p, param[1]) && for_all$1(p, param[4]));
-  }
-  else {
-    return /* true */1;
-  }
+function for_all$1(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        if (for_all$1(p, param[1])) {
+          _param = param[4];
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    }
+    else {
+      return /* true */1;
+    }
+  };
 }
 
-function exists$1(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) || exists$1(p, param[1]) || exists$1(p, param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function exists$1(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        return /* true */1;
+      }
+      else if (exists$1(p, param[1])) {
+        return /* true */1;
+      }
+      else {
+        _param = param[4];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function add_min_binding$1(k, v, param) {
@@ -1360,10 +1436,23 @@ function compare$1(cmp, m1, m2) {
 }
 
 function equal$1(cmp, m1, m2) {
-  var equal_aux = function (e1, e2) {
+  var _e1 = cons_enum$1(m1, /* End */0);
+  var _e2 = cons_enum$1(m2, /* End */0);
+  while(true) {
+    var e2 = _e2;
+    var e1 = _e1;
     if (e1) {
       if (e2) {
-        return +(Caml_string.caml_string_compare(e1[1], e2[1]) === 0 && cmp(e1[2], e2[2]) && equal_aux(cons_enum$1(e1[3], e1[4]), cons_enum$1(e2[3], e2[4])));
+        if (Caml_string.caml_string_compare(e1[1], e2[1])) {
+          return /* false */0;
+        }
+        else if (cmp(e1[2], e2[2])) {
+          _e2 = cons_enum$1(e2[3], e2[4]);
+          _e1 = cons_enum$1(e1[3], e1[4]);
+        }
+        else {
+          return /* false */0;
+        }
       }
       else {
         return /* false */0;
@@ -1376,7 +1465,6 @@ function equal$1(cmp, m1, m2) {
       return /* true */1;
     }
   };
-  return equal_aux(cons_enum$1(m1, /* End */0), cons_enum$1(m2, /* End */0));
 }
 
 function cardinal$1(param) {
@@ -1595,14 +1683,22 @@ function find$2(x, _param) {
   };
 }
 
-function mem$2(x, param) {
-  if (param) {
-    var c = Caml_primitive.caml_int_compare(x, param[2]);
-    return +(c === 0 || mem$2(x, c < 0 ? param[1] : param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem$2(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      var c = Caml_primitive.caml_int_compare(x, param[2]);
+      if (c) {
+        _param = c < 0 ? param[1] : param[4];
+      }
+      else {
+        return /* true */1;
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function min_binding$2(_param) {
@@ -1768,22 +1864,46 @@ function fold$2(f, _m, _accu) {
   };
 }
 
-function for_all$2(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) && for_all$2(p, param[1]) && for_all$2(p, param[4]));
-  }
-  else {
-    return /* true */1;
-  }
+function for_all$2(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        if (for_all$2(p, param[1])) {
+          _param = param[4];
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    }
+    else {
+      return /* true */1;
+    }
+  };
 }
 
-function exists$2(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) || exists$2(p, param[1]) || exists$2(p, param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function exists$2(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        return /* true */1;
+      }
+      else if (exists$2(p, param[1])) {
+        return /* true */1;
+      }
+      else {
+        _param = param[4];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function add_min_binding$2(k, v, param) {
@@ -2058,10 +2178,25 @@ function compare$2(cmp, m1, m2) {
 }
 
 function equal$2(cmp, m1, m2) {
-  var equal_aux = function (e1, e2) {
+  var _e1 = cons_enum$2(m1, /* End */0);
+  var _e2 = cons_enum$2(m2, /* End */0);
+  while(true) {
+    var e2 = _e2;
+    var e1 = _e1;
     if (e1) {
       if (e2) {
-        return +(e1[1] === e2[1] && cmp(e1[2], e2[2]) && equal_aux(cons_enum$2(e1[3], e1[4]), cons_enum$2(e2[3], e2[4])));
+        if (e1[1] === e2[1]) {
+          if (cmp(e1[2], e2[2])) {
+            _e2 = cons_enum$2(e2[3], e2[4]);
+            _e1 = cons_enum$2(e1[3], e1[4]);
+          }
+          else {
+            return /* false */0;
+          }
+        }
+        else {
+          return /* false */0;
+        }
       }
       else {
         return /* false */0;
@@ -2074,7 +2209,6 @@ function equal$2(cmp, m1, m2) {
       return /* true */1;
     }
   };
-  return equal_aux(cons_enum$2(m1, /* End */0), cons_enum$2(m2, /* End */0));
 }
 
 function cardinal$2(param) {

--- a/jscomp/test/test_list.js
+++ b/jscomp/test/test_list.js
@@ -322,74 +322,126 @@ function fold_right2(f, l1, l2, accu) {
   }
 }
 
-function for_all(p, param) {
-  if (param) {
-    return +(p(param[1]) && for_all(p, param[2]));
-  }
-  else {
-    return /* true */1;
-  }
-}
-
-function exists(p, param) {
-  if (param) {
-    return +(p(param[1]) || exists(p, param[2]));
-  }
-  else {
-    return /* false */0;
-  }
-}
-
-function for_all2(p, l1, l2) {
-  if (l1) {
-    if (l2) {
-      return +(p(l1[1], l2[1]) && for_all2(p, l1[2], l2[2]));
+function for_all(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[1])) {
+        _param = param[2];
+      }
+      else {
+        return /* false */0;
+      }
     }
     else {
+      return /* true */1;
+    }
+  };
+}
+
+function exists(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[1])) {
+        return /* true */1;
+      }
+      else {
+        _param = param[2];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
+}
+
+function for_all2(p, _l1, _l2) {
+  while(true) {
+    var l2 = _l2;
+    var l1 = _l1;
+    if (l1) {
+      if (l2) {
+        if (p(l1[1], l2[1])) {
+          _l2 = l2[2];
+          _l1 = l1[2];
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return Pervasives.invalid_arg("List.for_all2");
+      }
+    }
+    else if (l2) {
       return Pervasives.invalid_arg("List.for_all2");
     }
-  }
-  else if (l2) {
-    return Pervasives.invalid_arg("List.for_all2");
-  }
-  else {
-    return /* true */1;
-  }
+    else {
+      return /* true */1;
+    }
+  };
 }
 
-function exists2(p, l1, l2) {
-  if (l1) {
-    if (l2) {
-      return +(p(l1[1], l2[1]) || exists2(p, l1[2], l2[2]));
+function exists2(p, _l1, _l2) {
+  while(true) {
+    var l2 = _l2;
+    var l1 = _l1;
+    if (l1) {
+      if (l2) {
+        if (p(l1[1], l2[1])) {
+          return /* true */1;
+        }
+        else {
+          _l2 = l2[2];
+          _l1 = l1[2];
+        }
+      }
+      else {
+        return Pervasives.invalid_arg("List.exists2");
+      }
     }
-    else {
+    else if (l2) {
       return Pervasives.invalid_arg("List.exists2");
     }
-  }
-  else if (l2) {
-    return Pervasives.invalid_arg("List.exists2");
-  }
-  else {
-    return /* false */0;
-  }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
-function mem(x, param) {
-  if (param) {
-    return +(Caml_primitive.caml_compare(param[1], x) === 0 || mem(x, param[2]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (Caml_primitive.caml_compare(param[1], x)) {
+        _param = param[2];
+      }
+      else {
+        return /* true */1;
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
-function memq(x, param) {
-  if (param) {
-    return +(param[1] === x || memq(x, param[2]));
-  }
-  else {
-    return /* false */0;
-  }
+function memq(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (param[1] === x) {
+        return /* true */1;
+      }
+      else {
+        _param = param[2];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function assoc(x, _param) {
@@ -428,22 +480,38 @@ function assq(x, _param) {
   };
 }
 
-function mem_assoc(x, param) {
-  if (param) {
-    return +(Caml_primitive.caml_compare(param[1][1], x) === 0 || mem_assoc(x, param[2]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem_assoc(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (Caml_primitive.caml_compare(param[1][1], x)) {
+        _param = param[2];
+      }
+      else {
+        return /* true */1;
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
-function mem_assq(x, param) {
-  if (param) {
-    return +(param[1][1] === x || mem_assq(x, param[2]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem_assq(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (param[1][1] === x) {
+        return /* true */1;
+      }
+      else {
+        _param = param[2];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function remove_assoc(x, param) {

--- a/jscomp/test/test_order_tailcall.js
+++ b/jscomp/test/test_order_tailcall.js
@@ -53,11 +53,45 @@ function f5(_x, _y, z) {
 }
 
 function f6(b) {
-  return +(b && f6(b));
+  while(true) {
+    if (b) {
+      if (b) {
+        if (b) {
+          if (!b) {
+            return /* false */0;
+          }
+          
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function f7(b) {
-  return +(b || f7(b));
+  while(true) {
+    if (b) {
+      return /* true */1;
+    }
+    else if (b) {
+      return /* true */1;
+    }
+    else if (b) {
+      return /* true */1;
+    }
+    else if (b) {
+      return /* true */1;
+    }
+    
+  };
 }
 
 function f8(_x, _y) {

--- a/jscomp/test/test_set.js
+++ b/jscomp/test/test_set.js
@@ -279,14 +279,22 @@ function Make(Ord) {
       return /* true */1;
     }
   };
-  var mem = function (x, param) {
-    if (param) {
-      var c = Ord[1](x, param[2]);
-      return +(c === 0 || mem(x, c < 0 ? param[1] : param[3]));
-    }
-    else {
-      return /* false */0;
-    }
+  var mem = function (x, _param) {
+    while(true) {
+      var param = _param;
+      if (param) {
+        var c = Ord[1](x, param[2]);
+        if (c) {
+          _param = c < 0 ? param[1] : param[3];
+        }
+        else {
+          return /* true */1;
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    };
   };
   var remove = function (x, param) {
     if (param) {
@@ -439,46 +447,62 @@ function Make(Ord) {
   var equal = function (s1, s2) {
     return +(compare(s1, s2) === 0);
   };
-  var subset = function (s1, s2) {
-    if (s1) {
-      if (s2) {
-        var r2 = s2[3];
-        var l2 = s2[1];
-        var r1 = s1[3];
-        var v1 = s1[2];
-        var l1 = s1[1];
-        var c = Ord[1](v1, s2[2]);
-        if (c) {
-          if (c < 0) {
-            return +(subset([
-                          /* Node */0,
-                          l1,
-                          v1,
-                          /* Empty */0,
-                          0
-                        ], l2) && subset(r1, s2));
+  var subset = function (_s1, _s2) {
+    while(true) {
+      var s2 = _s2;
+      var s1 = _s1;
+      if (s1) {
+        if (s2) {
+          var r2 = s2[3];
+          var l2 = s2[1];
+          var r1 = s1[3];
+          var v1 = s1[2];
+          var l1 = s1[1];
+          var c = Ord[1](v1, s2[2]);
+          if (c) {
+            if (c < 0) {
+              if (subset([
+                      /* Node */0,
+                      l1,
+                      v1,
+                      /* Empty */0,
+                      0
+                    ], l2)) {
+                _s1 = r1;
+              }
+              else {
+                return /* false */0;
+              }
+            }
+            else if (subset([
+                    /* Node */0,
+                    /* Empty */0,
+                    v1,
+                    r1,
+                    0
+                  ], r2)) {
+              _s1 = l1;
+            }
+            else {
+              return /* false */0;
+            }
+          }
+          else if (subset(l1, l2)) {
+            _s2 = r2;
+            _s1 = r1;
           }
           else {
-            return +(subset([
-                          /* Node */0,
-                          /* Empty */0,
-                          v1,
-                          r1,
-                          0
-                        ], r2) && subset(l1, s2));
+            return /* false */0;
           }
         }
         else {
-          return +(subset(l1, l2) && subset(r1, r2));
+          return /* false */0;
         }
       }
       else {
-        return /* false */0;
+        return /* true */1;
       }
-    }
-    else {
-      return /* true */1;
-    }
+    };
   };
   var iter = function (f, _param) {
     while(true) {
@@ -506,21 +530,45 @@ function Make(Ord) {
       }
     };
   };
-  var for_all = function (p, param) {
-    if (param) {
-      return +(p(param[2]) && for_all(p, param[1]) && for_all(p, param[3]));
-    }
-    else {
-      return /* true */1;
-    }
+  var for_all = function (p, _param) {
+    while(true) {
+      var param = _param;
+      if (param) {
+        if (p(param[2])) {
+          if (for_all(p, param[1])) {
+            _param = param[3];
+          }
+          else {
+            return /* false */0;
+          }
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return /* true */1;
+      }
+    };
   };
-  var exists = function (p, param) {
-    if (param) {
-      return +(p(param[2]) || exists(p, param[1]) || exists(p, param[3]));
-    }
-    else {
-      return /* false */0;
-    }
+  var exists = function (p, _param) {
+    while(true) {
+      var param = _param;
+      if (param) {
+        if (p(param[2])) {
+          return /* true */1;
+        }
+        else if (exists(p, param[1])) {
+          return /* true */1;
+        }
+        else {
+          _param = param[3];
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    };
   };
   var filter = function (p, param) {
     if (param) {

--- a/jscomp/test/test_string.js
+++ b/jscomp/test/test_string.js
@@ -38,7 +38,12 @@ function c(x, y) {
 var v = 2;
 
 function h(s, b) {
-  return +(s[0] === "a" && b[0] === /* "b" */98 && s.charCodeAt(1) === b[2]);
+  if (s[0] === "a" && b[0] === /* "b" */98) {
+    return +(s.charCodeAt(1) === b[2]);
+  }
+  else {
+    return /* false */0;
+  }
 }
 
 exports.f = f;

--- a/jscomp/test/ticker.js
+++ b/jscomp/test/ticker.js
@@ -289,14 +289,22 @@ function find(x, _param) {
   };
 }
 
-function mem(x, param) {
-  if (param) {
-    var c = Caml_primitive.caml_compare(x, param[2]);
-    return +(c === 0 || mem(x, c < 0 ? param[1] : param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function mem(x, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      var c = Caml_primitive.caml_compare(x, param[2]);
+      if (c) {
+        _param = c < 0 ? param[1] : param[4];
+      }
+      else {
+        return /* true */1;
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function min_binding(_param) {
@@ -462,22 +470,46 @@ function fold(f, _m, _accu) {
   };
 }
 
-function for_all(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) && for_all(p, param[1]) && for_all(p, param[4]));
-  }
-  else {
-    return /* true */1;
-  }
+function for_all(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        if (for_all(p, param[1])) {
+          _param = param[4];
+        }
+        else {
+          return /* false */0;
+        }
+      }
+      else {
+        return /* false */0;
+      }
+    }
+    else {
+      return /* true */1;
+    }
+  };
 }
 
-function exists(p, param) {
-  if (param) {
-    return +(p(param[2], param[3]) || exists(p, param[1]) || exists(p, param[4]));
-  }
-  else {
-    return /* false */0;
-  }
+function exists(p, _param) {
+  while(true) {
+    var param = _param;
+    if (param) {
+      if (p(param[2], param[3])) {
+        return /* true */1;
+      }
+      else if (exists(p, param[1])) {
+        return /* true */1;
+      }
+      else {
+        _param = param[4];
+      }
+    }
+    else {
+      return /* false */0;
+    }
+  };
 }
 
 function add_min_binding(k, v, param) {
@@ -752,10 +784,23 @@ function compare(cmp, m1, m2) {
 }
 
 function equal(cmp, m1, m2) {
-  var equal_aux = function (e1, e2) {
+  var _e1 = cons_enum(m1, /* End */0);
+  var _e2 = cons_enum(m2, /* End */0);
+  while(true) {
+    var e2 = _e2;
+    var e1 = _e1;
     if (e1) {
       if (e2) {
-        return +(Caml_primitive.caml_compare(e1[1], e2[1]) === 0 && cmp(e1[2], e2[2]) && equal_aux(cons_enum(e1[3], e1[4]), cons_enum(e2[3], e2[4])));
+        if (Caml_primitive.caml_compare(e1[1], e2[1])) {
+          return /* false */0;
+        }
+        else if (cmp(e1[2], e2[2])) {
+          _e2 = cons_enum(e2[3], e2[4]);
+          _e1 = cons_enum(e1[3], e1[4]);
+        }
+        else {
+          return /* false */0;
+        }
       }
       else {
         return /* false */0;
@@ -768,7 +813,6 @@ function equal(cmp, m1, m2) {
       return /* true */1;
     }
   };
-  return equal_aux(cons_enum(m1, /* End */0), cons_enum(m2, /* End */0));
 }
 
 function cardinal(param) {


### PR DESCRIPTION
for things like `return +(code>31 && code< 96)`,  we can improve it later