### PR TITLE
Simplify length

### DIFF
--- a/jscomp/j.ml
+++ b/jscomp/j.ml
@@ -86,14 +86,10 @@ and for_direction = Asttypes.direction_flag
 
 and property_map = 
     (property_name * expression) list
-
+and length_object = Js_op.length_object
 and expression_desc =
   | Math of string * expression list
-  | Array_length of expression
-  | String_length of expression
-  | Bytes_length of expression
-  | Function_length of expression 
-
+  | Length of expression * length_object
   | Char_of_int of expression
   | Char_to_int of expression 
   | Array_of_size of expression 
@@ -220,7 +216,6 @@ and expression_desc =
   *)
   | Caml_block_tag of expression
   | Caml_block_set_tag of expression * expression
-  | Caml_block_length of expression
   | Caml_block_set_length of expression * expression
   (* It will just fetch tag, to make it safe, when creating it, 
      we need apply "|0", we don't do it in the 

--- a/jscomp/js_analyzer.ml
+++ b/jscomp/js_analyzer.ml
@@ -90,11 +90,7 @@ let rec no_side_effect (x : J.expression)  =
   | Array_append (a,b) 
   | String_append (a,b)
   | Seq (a,b) -> no_side_effect a && no_side_effect b 
-  | Caml_block_length e
-  | Array_length e
-  | String_length e 
-  | Bytes_length e 
-  | Function_length e
+  | Length (e, _)
   | Char_of_int e 
   | Char_to_int e 
   | Caml_block_tag e 

--- a/jscomp/js_dump.ml
+++ b/jscomp/js_dump.ml
@@ -379,7 +379,6 @@ and
   match x with
   | Var v ->
     vident cxt f v 
-
   | Seq (e1, e2) ->
     let action () = 
       let cxt = expression 0 cxt f e1 in
@@ -590,7 +589,7 @@ and
   | Caml_block_set_length(a,b) -> 
     expression_desc cxt l f 
       (Bin(Eq, 
-           {expression_desc = Caml_block_length a; comment = None},
+           {expression_desc = Length (a,Caml_block); comment = None},
            b
           ))
   | Bin (Eq, {expression_desc = Var i },
@@ -808,8 +807,7 @@ and
     in
     if l > 15 then P.paren_group f 1 action else action ()
 
-  | Array_length e | String_length e | Bytes_length e 
-  | Function_length e | Caml_block_length e -> 
+  | Length (e, _) -> 
     let action () =  (** Todo: check parens *)
       let cxt = expression 15 cxt f e in
       P.string f L.dot;
@@ -1031,14 +1029,13 @@ and statement_desc top cxt f (s : J.statement_desc) : Ext_pp_scope.t =
       | Caml_uninitialized_obj _ 
       | Fun _ | Object _ -> true
       | Caml_block_set_tag _ 
-      | Caml_block_length _
+      | Length _ 
       | Caml_block_set_length _ 
       | Anything_to_string _ 
       | String_of_small_int_array _
       | Call _ 
       | Array_append _ 
       | Array_copy _ 
-      (* | Tag_ml_obj _ *)
       | Caml_block_tag _ 
       | Seq _
       | Dot _
@@ -1047,9 +1044,6 @@ and statement_desc top cxt f (s : J.statement_desc) : Ext_pp_scope.t =
       | String_access _ 
       | Access _
       | Array_of_size _ 
-      | Array_length _
-      | String_length _ 
-      | Bytes_length _
       | String_append _ 
       | Char_of_int _ 
       | Char_to_int _
@@ -1062,7 +1056,6 @@ and statement_desc top cxt f (s : J.statement_desc) : Ext_pp_scope.t =
       | Caml_block  _ 
       | FlatCall _ 
       | Typeof _
-      | Function_length _ 
       | Number _
       | Not _ 
       | New _ 

--- a/jscomp/js_fold.ml
+++ b/jscomp/js_fold.ml
@@ -324,6 +324,7 @@ class virtual fold =
         let o = o#exports _x_i2 in let o = o#unknown _x_i3 in o
     method number : number -> 'self_type = o#unknown
     method mutable_flag : mutable_flag -> 'self_type = o#unknown
+    method length_object : length_object -> 'self_type = o#unknown
     method label : label -> 'self_type = o#string
     method kind : kind -> 'self_type = o#unknown
     method int_op : int_op -> 'self_type = o#unknown
@@ -340,10 +341,8 @@ class virtual fold =
       | Math (_x, _x_i1) ->
           let o = o#string _x in
           let o = o#list (fun o -> o#expression) _x_i1 in o
-      | Array_length _x -> let o = o#expression _x in o
-      | String_length _x -> let o = o#expression _x in o
-      | Bytes_length _x -> let o = o#expression _x in o
-      | Function_length _x -> let o = o#expression _x in o
+      | Length (_x, _x_i1) ->
+          let o = o#expression _x in let o = o#length_object _x_i1 in o
       | Char_of_int _x -> let o = o#expression _x in o
       | Char_to_int _x -> let o = o#expression _x in o
       | Array_of_size _x -> let o = o#expression _x in o
@@ -403,7 +402,6 @@ class virtual fold =
       | Caml_block_tag _x -> let o = o#expression _x in o
       | Caml_block_set_tag (_x, _x_i1) ->
           let o = o#expression _x in let o = o#expression _x_i1 in o
-      | Caml_block_length _x -> let o = o#expression _x in o
       | Caml_block_set_length (_x, _x_i1) ->
           let o = o#expression _x in let o = o#expression _x_i1 in o
       | Number _x -> let o = o#number _x in o

--- a/jscomp/js_helper.ml
+++ b/jscomp/js_helper.ml
@@ -222,31 +222,40 @@ module Exp = struct
    *)
   let dot ?comment (e0 : t)  (e1 : string) : t = 
     { expression_desc = Dot (e0,  e1, true); comment} 
+
+  let undefined  = js_global "undefined"
+
+
+  (** coupled with the runtime *)
+  let is_caml_block ?comment (e : t) : t = 
+    {expression_desc = Bin ( NotEqEq, dot e "length" , undefined); 
+     comment}
+
   (* This is a property access not external module *)
   
   let array_length ?comment (e : t) : t = 
     match e.expression_desc with 
       (* TODO: use array instead? *)
     | Array (l, _) -> int ?comment (List.length l)
-    | _ -> { expression_desc = Array_length e ; comment }
+    | _ -> { expression_desc = Length (e, Array) ; comment }
 
   let string_length ?comment (e : t) : t =
     match e.expression_desc with 
     | Str(_,v) -> int ?comment (String.length v)
-    | _ -> { expression_desc = String_length e ; comment }
+    | _ -> { expression_desc = Length (e, String) ; comment }
 
   let bytes_length ?comment (e : t) : t = 
     match e.expression_desc with 
       (* TODO: use array instead? *)
     | Array (l, _) -> int ?comment (List.length l)
     | Str(_,v) -> int ?comment (String.length v)
-    | _ -> { expression_desc = Bytes_length e ; comment }
+    | _ -> { expression_desc = Length (e, Bytes) ; comment }
 
   let function_length ?comment (e : t) : t = 
     match e.expression_desc with 
     | Fun(params, _, _) -> int ?comment (List.length params)
      (* TODO: optimize if [e] is know at compile time *)
-    | _ -> { expression_desc = Function_length e ; comment }
+    | _ -> { expression_desc = Length (e, Function) ; comment }
 
       (** no dependency introduced *)
   let js_global_dot ?comment (x : string)  (e1 : string) : t = 
@@ -458,16 +467,12 @@ module Exp = struct
       econd ?comment x f t 
 
     | (Bin (Ge, 
-            ({expression_desc = 
-                (String_length _ 
-                | Array_length _ | Bytes_length _ | Function_length _ );
+            ({expression_desc = Length _ ;
               _}), {expression_desc = Number (Int { i = 0 ; _})})), _, _ 
       -> f
 
     | (Bin (Gt, 
-            ({expression_desc = 
-                (String_length _ 
-                | Array_length _ | Bytes_length _ | Function_length _ );
+            ({expression_desc = Length _;
               _} as pred ), {expression_desc = Number (Int {i = 0; })})), _, _
       ->
       (** Add comment when simplified *)
@@ -602,8 +607,7 @@ module Exp = struct
   let typeof ?comment (e : t) : t = 
     match e.expression_desc with 
     | Number _ 
-    | Array_length _ 
-    | String_length _ 
+    | Length _ 
       -> str ?comment "number"
     | Str _ 
       -> str ?comment "string" 
@@ -627,7 +631,7 @@ module Exp = struct
 
   let unit  () = int ~comment:"()" 0;; (* TODO: add a comment *)
 
-  let undefined ?comment () = js_global ?comment "undefined"
+
 
   let math ?comment v args  : t = 
     {comment ; expression_desc = Math(v,args)}
@@ -673,7 +677,7 @@ module Exp = struct
   let set_length ?comment e tag : t = 
     seq {expression_desc = Caml_block_set_length (e,tag); comment } (unit ())
   let obj_length ?comment e : t = 
-    {expression_desc = Caml_block_length e; comment }
+    {expression_desc = Length (e, Caml_block); comment }
   (* Arithmatic operations
      TODO: distinguish between int and float
      TODO: Note that we have to use Int64 to avoid integer overflow, this is fine
@@ -1122,7 +1126,7 @@ module Stmt = struct
           end
       |  (Number _ , _, _
       | (Bin (Ge, 
-              ({expression_desc = (String_length _ | Array_length _ | Bytes_length _ | Function_length _ );
+              ({expression_desc = Length _;
                _}), {expression_desc = Number (Int { i = 0; _})})), _ , _)
             (* TODO: always 
                 turn [Le] -> into [Ge]
@@ -1145,8 +1149,7 @@ module Stmt = struct
 
       | ((Bin (Gt, 
                ({expression_desc = 
-                   (String_length _ 
-                   | Array_length _ | Bytes_length _ | Function_length _ );
+                   Length _;
                  _} as e ), {expression_desc = Number (Int { i = 0; _})}))
 
         | Int_of_boolean e), _ , _

--- a/jscomp/js_helper.mli
+++ b/jscomp/js_helper.mli
@@ -205,8 +205,8 @@ module Exp : sig
 
   val js_global : ?comment:string -> string -> t
 
-  val undefined : ?comment:string -> unit -> t
-
+  val undefined : t
+  val is_caml_block : ?comment:string -> t -> t
   val math : ?comment:string -> string -> t list -> t
   (** [math "abs"] --> Math["abs"] *)    
 

--- a/jscomp/js_map.ml
+++ b/jscomp/js_map.ml
@@ -347,6 +347,7 @@ class virtual map =
         in { name = _x; block = _x_i1; exports = _x_i2; export_set = _x_i3; }
     method number : number -> number = o#unknown
     method mutable_flag : mutable_flag -> mutable_flag = o#unknown
+    method length_object : length_object -> length_object = o#unknown
     method label : label -> label = o#string
     method kind : kind -> kind = o#unknown
     method int_op : int_op -> int_op = o#unknown
@@ -364,10 +365,9 @@ class virtual map =
           let _x = o#string _x in
           let _x_i1 = o#list (fun o -> o#expression) _x_i1
           in Math (_x, _x_i1)
-      | Array_length _x -> let _x = o#expression _x in Array_length _x
-      | String_length _x -> let _x = o#expression _x in String_length _x
-      | Bytes_length _x -> let _x = o#expression _x in Bytes_length _x
-      | Function_length _x -> let _x = o#expression _x in Function_length _x
+      | Length (_x, _x_i1) ->
+          let _x = o#expression _x in
+          let _x_i1 = o#length_object _x_i1 in Length (_x, _x_i1)
       | Char_of_int _x -> let _x = o#expression _x in Char_of_int _x
       | Char_to_int _x -> let _x = o#expression _x in Char_to_int _x
       | Array_of_size _x -> let _x = o#expression _x in Array_of_size _x
@@ -447,8 +447,6 @@ class virtual map =
       | Caml_block_set_tag (_x, _x_i1) ->
           let _x = o#expression _x in
           let _x_i1 = o#expression _x_i1 in Caml_block_set_tag (_x, _x_i1)
-      | Caml_block_length _x ->
-          let _x = o#expression _x in Caml_block_length _x
       | Caml_block_set_length (_x, _x_i1) ->
           let _x = o#expression _x in
           let _x_i1 = o#expression _x_i1 in Caml_block_set_length (_x, _x_i1)

--- a/jscomp/js_op.ml
+++ b/jscomp/js_op.ml
@@ -215,6 +215,12 @@ type tag_info = Lambda.tag_info =
   | Record 
   | NA
 
+type length_object = 
+  | Array 
+  | String
+  | Bytes
+  | Function
+  | Caml_block
 (** TODO: define constant - for better constant folding  *)
 (* type constant =  *)
 (*   | Const_int of int *)

--- a/jscomp/lam_compile.ml
+++ b/jscomp/lam_compile.ml
@@ -610,7 +610,8 @@ and
             cxt with should_return = False; st = NeedValue} e with 
         | {block = b; value =  Some v} -> 
 
-          Js_output.make (b @ [S.throw v]) ~value:(E.undefined ()) ~finished:True
+          Js_output.make (b @ [S.throw v])
+            ~value:E.undefined ~finished:True
         (* FIXME -- breaks invariant when NeedValue, reason is that js [throw] is statement 
            while ocaml it's an expression, we should remove such things in lambda optimizations
         *)
@@ -940,7 +941,7 @@ and
           in
           args_code ++ (* Declared in [Lstaticraise ]*)
           Js_output.make [S.assign exit_id (E.int order_id)]
-            ~value:(E.undefined ())
+            ~value:E.undefined
         | exception Not_found ->
           Js_output.make [S.unknown_lambda ~comment:"error" lam]
           (* staticraise is always enclosed by catch  *)

--- a/jscomp/lam_compile_external_call.ml
+++ b/jscomp/lam_compile_external_call.ml
@@ -235,7 +235,7 @@ let ocaml_to_js last (js_splice : bool) ((label : string), (ty : Types.type_expr
           (*   (E.str "number")) *)
 
           [E.econd arg
-             (E.undefined ())
+             E.undefined
              (E.index arg 1)]
       end
     | _ ->  [arg]  
@@ -280,7 +280,7 @@ let translate
                              E.econd arg
                                (* (E.bin EqEqEq (E.typeof arg) *)
                                (*   (E.str "number")) *)
-                               (E.undefined ())
+                               E.undefined
                                (E.index arg 1))
                   end)                   
               arg_types args 

--- a/jscomp/lam_dispatch_primitive.ml
+++ b/jscomp/lam_dispatch_primitive.ml
@@ -537,6 +537,11 @@ let query (prim : Lam_compile_env.primitive_description)
 
 
     | "caml_obj_is_block"
+      -> 
+      begin match args with 
+        | [e] -> E.is_caml_block e 
+        | _ -> assert false
+      end
     | "caml_obj_truncate"
     | "caml_lazy_make_forward"
     | "caml_compare"

--- a/jscomp/runtime/caml_obj.d.ts
+++ b/jscomp/runtime/caml_obj.d.ts
@@ -1,6 +1,5 @@
 export var caml_obj_dup: (x : any) => any ;
 export var caml_obj_truncate: (x : any, new_size : any) => any ;
-export var caml_obj_is_block: (x : any) => any ;
 export var caml_lazy_make_forward: (x : any) => any ;
 export var caml_update_dummy: (x : any, y : any) => any ;
 export var caml_int_compare: (x : any, y : any) => any ;

--- a/jscomp/runtime/caml_obj.js
+++ b/jscomp/runtime/caml_obj.js
@@ -35,10 +35,6 @@ function caml_obj_truncate(x, new_size) {
   }
 }
 
-function caml_obj_is_block(x) {
-  return +(typeof x.length === "undefined");
-}
-
 function caml_lazy_make_forward(x) {
   return {
           0: x,
@@ -288,7 +284,6 @@ var caml_nativeint_compare = caml_int_compare;
 
 exports.caml_obj_dup           = caml_obj_dup;
 exports.caml_obj_truncate      = caml_obj_truncate;
-exports.caml_obj_is_block      = caml_obj_is_block;
 exports.caml_lazy_make_forward = caml_lazy_make_forward;
 exports.caml_update_dummy      = caml_update_dummy;
 exports.caml_int_compare       = caml_int_compare;

--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -62,8 +62,6 @@ let caml_obj_truncate (x : Obj.t) (new_size : int) =
     end
 
      
-let caml_obj_is_block x = 
-  js_typeof (Obj.repr (js_obj_length x )) = "undefined"
 
 let caml_lazy_make_forward x = lazy x 
 

--- a/jscomp/runtime/caml_obj.mli
+++ b/jscomp/runtime/caml_obj.mli
@@ -22,20 +22,7 @@ val caml_obj_dup : Obj.t -> Obj.t
 
 val caml_obj_truncate : Obj.t -> int -> unit
 
-(** 
 
-   TODO: Semantics difference 
-   {[
-   Obj.is_block (Obj.repr "x");;
-   true   
-   ]}
-
-   {[
-     Obj.is_block (Obj.repr 32.0);;
-     true
-   ]}   
-*)
-val caml_obj_is_block : Obj.t -> bool
 
 val caml_lazy_make_forward : 'a -> 'a lazy_t
 

--- a/jscomp/stdlib/obj.js
+++ b/jscomp/stdlib/obj.js
@@ -1,7 +1,6 @@
 // Generated CODE, PLEASE EDIT WITH CARE
 'use strict';
 
-var Caml_obj                = require("../runtime/caml_obj");
 var Caml_builtin_exceptions = require("../runtime/caml_builtin_exceptions");
 var Marshal                 = require("./marshal");
 var Caml_primitive          = require("../runtime/caml_primitive");
@@ -33,9 +32,9 @@ var string_tag = 252;
 var custom_tag = 255;
 
 function extension_slot(x) {
-  var slot = Caml_obj.caml_obj_is_block(x) && (x.tag | 0) !== object_tag && x.length >= 1 ? x[0] : x;
+  var slot = x.length !== undefined && (x.tag | 0) !== object_tag && x.length >= 1 ? x[0] : x;
   var name;
-  if (Caml_obj.caml_obj_is_block(slot) && (slot.tag | 0) === object_tag) {
+  if (slot.length !== undefined && (slot.tag | 0) === object_tag) {
     name = slot[0];
   }
   else {

--- a/jscomp/stdlib/obj.js
+++ b/jscomp/stdlib/obj.js
@@ -32,9 +32,9 @@ var string_tag = 252;
 var custom_tag = 255;
 
 function extension_slot(x) {
-  var slot = x.length !== undefined && (x.tag | 0) !== object_tag && x.length >= 1 ? x[0] : x;
+  var slot = x.length && (x.tag | 0) !== object_tag && x.length >= 1 ? x[0] : x;
   var name;
-  if (slot.length !== undefined && (slot.tag | 0) === object_tag) {
+  if (slot.length && (slot.tag | 0) === object_tag) {
     name = slot[0];
   }
   else {

--- a/jscomp/stdlib/parsing.js
+++ b/jscomp/stdlib/parsing.js
@@ -154,7 +154,7 @@ function yyparse(tables, start, lexer, lexbuf) {
     }
     else {
       current_lookahead_fun[0] = function (tok) {
-        if (Caml_obj.caml_obj_is_block(tok)) {
+        if (tok.length !== undefined) {
           return +(tables[2][tok.tag | 0] === curr_char);
         }
         else {

--- a/jscomp/stdlib/parsing.js
+++ b/jscomp/stdlib/parsing.js
@@ -154,7 +154,7 @@ function yyparse(tables, start, lexer, lexbuf) {
     }
     else {
       current_lookahead_fun[0] = function (tok) {
-        if (tok.length !== undefined) {
+        if (tok.length) {
           return +(tables[2][tok.tag | 0] === curr_char);
         }
         else {

--- a/jscomp/stdlib/printexc.js
+++ b/jscomp/stdlib/printexc.js
@@ -1,7 +1,6 @@
 // Generated CODE, PLEASE EDIT WITH CARE
 'use strict';
 
-var Caml_obj                = require("../runtime/caml_obj");
 var Caml_builtin_exceptions = require("../runtime/caml_builtin_exceptions");
 var Caml_io                 = require("../runtime/caml_io");
 var Obj                     = require("./obj");
@@ -79,28 +78,7 @@ var locfmt = /* Format */{
 
 function field(x, i) {
   var f = x[i];
-  if (Caml_obj.caml_obj_is_block(f)) {
-    if ((f.tag | 0) === Obj.string_tag) {
-      return Caml_curry.app1(Printf.sprintf(/* Format */{
-                      0: /* Caml_string */{
-                        0: /* No_padding */0,
-                        1: /* End_of_format */0,
-                        length: 2,
-                        tag: 3
-                      },
-                      1: "%S",
-                      length: 2,
-                      tag: 0
-                    }), f);
-    }
-    else if ((f.tag | 0) === Obj.double_tag) {
-      return Pervasives.string_of_float(f);
-    }
-    else {
-      return "_";
-    }
-  }
-  else {
+  if (f.length === undefined) {
     return Caml_curry.app1(Printf.sprintf(/* Format */{
                     0: /* Int */{
                       0: /* Int_d */0,
@@ -114,6 +92,25 @@ function field(x, i) {
                     length: 2,
                     tag: 0
                   }), f);
+  }
+  else if ((f.tag | 0) === Obj.string_tag) {
+    return Caml_curry.app1(Printf.sprintf(/* Format */{
+                    0: /* Caml_string */{
+                      0: /* No_padding */0,
+                      1: /* End_of_format */0,
+                      length: 2,
+                      tag: 3
+                    },
+                    1: "%S",
+                    length: 2,
+                    tag: 0
+                  }), f);
+  }
+  else if ((f.tag | 0) === Obj.double_tag) {
+    return Pervasives.string_of_float(f);
+  }
+  else {
+    return "_";
   }
 }
 

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -153,8 +153,8 @@ mt.cmo : ../stdlib/list.cmi mt.cmi
 mt.cmx : ../stdlib/list.cmx mt.cmi
 number_lexer.cmo : ../stdlib/sys.cmi ../stdlib/lexing.cmi
 number_lexer.cmx : ../stdlib/sys.cmx ../stdlib/lexing.cmx
-obj_magic_test.cmo : ../stdlib/obj.cmi
-obj_magic_test.cmx : ../stdlib/obj.cmx
+obj_magic_test.cmo : ../stdlib/obj.cmi mt.cmi
+obj_magic_test.cmx : ../stdlib/obj.cmx mt.cmx
 obj_test.cmo : mt.cmi
 obj_test.cmx : mt.cmx
 of_string_test.cmo : mt.cmi
@@ -541,8 +541,8 @@ mt.cmo : ../stdlib/list.cmi mt.cmi
 mt.cmj : ../stdlib/list.cmj mt.cmi
 number_lexer.cmo : ../stdlib/sys.cmi ../stdlib/lexing.cmi
 number_lexer.cmj : ../stdlib/sys.cmj ../stdlib/lexing.cmj
-obj_magic_test.cmo : ../stdlib/obj.cmi
-obj_magic_test.cmj : ../stdlib/obj.cmj
+obj_magic_test.cmo : ../stdlib/obj.cmi mt.cmi
+obj_magic_test.cmj : ../stdlib/obj.cmj mt.cmj
 obj_test.cmo : mt.cmi
 obj_test.cmj : mt.cmj
 of_string_test.cmo : mt.cmi

--- a/jscomp/test/obj_magic_test.d.ts
+++ b/jscomp/test/obj_magic_test.d.ts
@@ -1,2 +1,4 @@
 export var empty_backtrace: any ;
+export var is_block: (x : any) => any ;
+export var suites: any ;
 

--- a/jscomp/test/obj_magic_test.js
+++ b/jscomp/test/obj_magic_test.js
@@ -2,11 +2,81 @@
 'use strict';
 
 var Obj = require("../stdlib/obj");
+var Mt  = require("./mt");
 
 var empty_backtrace = {
   length: 0,
   tag: Obj.abstract_tag
 };
 
+function is_block(x) {
+  return x.length !== undefined;
+}
+
+var suites_000 = /* tuple */[
+  "is_block_test1",
+  function () {
+    return /* Eq */{
+            0: /* false */0,
+            1: (3).length !== undefined,
+            length: 2,
+            tag: 0
+          };
+  }
+];
+
+var suites_001 = /* :: */[
+  /* tuple */[
+    "is_block_test2",
+    function () {
+      return /* Eq */{
+              0: /* true */1,
+              1: /* :: */[
+                3,
+                /* [] */0
+              ].length !== undefined,
+              length: 2,
+              tag: 0
+            };
+    }
+  ],
+  /* :: */[
+    /* tuple */[
+      "is_block_test3",
+      function () {
+        return /* Eq */{
+                0: /* true */1,
+                1: "x".length !== undefined,
+                length: 2,
+                tag: 0
+              };
+      }
+    ],
+    /* :: */[
+      /* tuple */[
+        "is_block_test4",
+        function () {
+          return /* Eq */{
+                  0: /* false */0,
+                  1: (3.0).length !== undefined,
+                  length: 2,
+                  tag: 0
+                };
+        }
+      ],
+      /* [] */0
+    ]
+  ]
+];
+
+var suites = /* :: */[
+  suites_000,
+  suites_001
+];
+
+Mt.from_pair_suites("obj_magic_test.ml", suites);
+
 exports.empty_backtrace = empty_backtrace;
-/* No side effect */
+exports.is_block        = is_block;
+exports.suites          = suites;
+/*  Not a pure module */

--- a/jscomp/test/obj_magic_test.ml
+++ b/jscomp/test/obj_magic_test.ml
@@ -1,2 +1,28 @@
 
+
+
 let empty_backtrace  = Obj.obj (Obj.new_block Obj.abstract_tag 0)
+
+let is_block x = (Obj.is_block @@ Obj.repr x)
+ 
+let suites = Mt.[
+"is_block_test1", (fun _ -> Eq (false, is_block 3));
+"is_block_test2", (fun _ -> Eq (true, is_block [3]));
+"is_block_test3", (fun _ -> Eq(true, is_block "x"));
+"is_block_test4", (fun _ -> Eq (false, is_block 3.0))
+]
+(** 
+
+   TODO: Semantics difference 
+   {[
+   Obj.is_block (Obj.repr "x");;
+   true   
+   ]}
+
+   {[
+     Obj.is_block (Obj.repr 32.0);;
+     true
+   ]}   
+*)
+
+;; Mt.from_pair_suites __FILE__ suites


### PR DESCRIPTION
1. use a uniform Length for various objects,
2. specialize handling `caml_obj_is_block`, we can not use `js_object_length` since it alreay assumes that it is a block